### PR TITLE
[#116] 인증/인가 로직 리팩토링

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -50,6 +50,7 @@ dependencies {
     annotationProcessor "jakarta.persistence:jakarta.persistence-api"
     annotationProcessor "jakarta.annotation:jakarta.annotation-api"
     annotationProcessor "com.querydsl:querydsl-apt:5.0.0:jakarta"
+
 }
 
 tasks.named('test') {

--- a/src/main/java/io/driver/codrive/DriverServerApplication.java
+++ b/src/main/java/io/driver/codrive/DriverServerApplication.java
@@ -4,10 +4,12 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.scheduling.annotation.EnableAsync;
 import org.springframework.scheduling.annotation.EnableScheduling;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 
 @SpringBootApplication
 @EnableScheduling
 @EnableAsync
+@EnableMethodSecurity
 public class DriverServerApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/io/driver/codrive/global/auth/AuthenticatedUser.java
+++ b/src/main/java/io/driver/codrive/global/auth/AuthenticatedUser.java
@@ -1,0 +1,11 @@
+package io.driver.codrive.global.auth;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface AuthenticatedUser {
+}

--- a/src/main/java/io/driver/codrive/global/auth/AuthenticatedUserArgumentResolver.java
+++ b/src/main/java/io/driver/codrive/global/auth/AuthenticatedUserArgumentResolver.java
@@ -1,0 +1,31 @@
+package io.driver.codrive.global.auth;
+
+import org.springframework.core.MethodParameter;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+import io.driver.codrive.global.util.AuthUtils;
+import io.driver.codrive.modules.user.domain.User;
+import io.driver.codrive.modules.user.service.UserService;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class AuthenticatedUserArgumentResolver implements HandlerMethodArgumentResolver {
+    private final UserService userService;
+
+    @Override
+    public boolean supportsParameter(MethodParameter parameter) {
+        return parameter.getParameterType().isAssignableFrom(User.class) && parameter.hasParameterAnnotation(AuthenticatedUser.class);
+    }
+
+    @Override
+    public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer, NativeWebRequest webRequest, WebDataBinderFactory binderFactory) {
+        Long authenticatedUserId = AuthUtils.getCurrentUserId();
+        if (authenticatedUserId == null) {
+            return null;
+        }
+        return userService.getUserById(authenticatedUserId);
+    }
+}

--- a/src/main/java/io/driver/codrive/global/auth/AuthenticatedUserId.java
+++ b/src/main/java/io/driver/codrive/global/auth/AuthenticatedUserId.java
@@ -1,0 +1,11 @@
+package io.driver.codrive.global.auth;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface AuthenticatedUserId {
+}

--- a/src/main/java/io/driver/codrive/global/auth/AuthenticatedUserIdArgumentResolver.java
+++ b/src/main/java/io/driver/codrive/global/auth/AuthenticatedUserIdArgumentResolver.java
@@ -1,0 +1,22 @@
+package io.driver.codrive.global.auth;
+
+import org.springframework.core.MethodParameter;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+import io.driver.codrive.global.util.AuthUtils;
+
+public class AuthenticatedUserIdArgumentResolver implements HandlerMethodArgumentResolver {
+
+    @Override
+    public boolean supportsParameter(MethodParameter parameter) {
+        return parameter.hasParameterAnnotation(AuthenticatedUserId.class);
+    }
+
+    @Override
+    public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer, NativeWebRequest webRequest, WebDataBinderFactory binderFactory) {
+        return AuthUtils.getCurrentUserId();
+    }
+}

--- a/src/main/java/io/driver/codrive/global/auth/AuthenticationToken.java
+++ b/src/main/java/io/driver/codrive/global/auth/AuthenticationToken.java
@@ -1,4 +1,4 @@
-package io.driver.codrive.global.jwt;
+package io.driver.codrive.global.auth;
 
 import org.springframework.security.authentication.AbstractAuthenticationToken;
 

--- a/src/main/java/io/driver/codrive/global/auth/JwtProvider.java
+++ b/src/main/java/io/driver/codrive/global/auth/JwtProvider.java
@@ -1,4 +1,4 @@
-package io.driver.codrive.global.jwt;
+package io.driver.codrive.global.auth;
 
 import java.util.Date;
 
@@ -8,7 +8,6 @@ import org.springframework.stereotype.Component;
 
 import io.driver.codrive.global.config.JwtConfig;
 import io.jsonwebtoken.Claims;
-import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.io.Decoders;
 import io.jsonwebtoken.security.Keys;
@@ -45,15 +44,10 @@ public class JwtProvider {
 	}
 
 	public Claims getClaims(String accessToken) {
-		try {
-			return Jwts.parser()
-				.verifyWith(secretKey)
-				.build()
-				.parseSignedClaims(accessToken)
-				.getPayload();
-		} catch (ExpiredJwtException e) {
-            log.error("Expired JWT token", e);
-            return e.getClaims();
-		}
+		return Jwts.parser()
+			.verifyWith(secretKey)
+			.build()
+			.parseSignedClaims(accessToken)
+			.getPayload();
 	}
 }

--- a/src/main/java/io/driver/codrive/global/auth/accessHandler/EntityAccessHandler.java
+++ b/src/main/java/io/driver/codrive/global/auth/accessHandler/EntityAccessHandler.java
@@ -1,0 +1,17 @@
+package io.driver.codrive.global.auth.accessHandler;
+
+import java.util.Objects;
+
+import org.springframework.stereotype.Component;
+
+import io.driver.codrive.global.util.AuthUtils;
+
+@Component
+public interface EntityAccessHandler {
+	boolean isOwner(Long entityId);
+
+	default boolean isSameWithCurrentUserId(Long ownerId) {
+		Long currentUserId = AuthUtils.getCurrentUserId();
+		return Objects.equals(currentUserId, ownerId);
+	}
+}

--- a/src/main/java/io/driver/codrive/global/auth/accessHandler/RecordAccessHandler.java
+++ b/src/main/java/io/driver/codrive/global/auth/accessHandler/RecordAccessHandler.java
@@ -1,0 +1,19 @@
+package io.driver.codrive.global.auth.accessHandler;
+
+import org.springframework.stereotype.Component;
+
+import io.driver.codrive.modules.record.service.RecordService;
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class RecordAccessHandler implements EntityAccessHandler {
+
+	private final RecordService recordService;
+
+	@Override
+	public boolean isOwner(Long recordId) {
+		Long ownerId = recordService.getOwnerIdByRecordId(recordId);
+		return isSameWithCurrentUserId(ownerId);
+	}
+}

--- a/src/main/java/io/driver/codrive/global/auth/accessHandler/RoomAccessHandler.java
+++ b/src/main/java/io/driver/codrive/global/auth/accessHandler/RoomAccessHandler.java
@@ -1,0 +1,19 @@
+package io.driver.codrive.global.auth.accessHandler;
+
+import org.springframework.stereotype.Component;
+
+import io.driver.codrive.modules.room.service.RoomService;
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class RoomAccessHandler implements EntityAccessHandler {
+
+	private final RoomService roomService;
+
+	@Override
+	public boolean isOwner(Long roomId) {
+		Long ownerId = roomService.getOwnerIdByRoomId(roomId);
+		return isSameWithCurrentUserId(ownerId);
+	}
+}

--- a/src/main/java/io/driver/codrive/global/auth/accessHandler/UserAccessHandler.java
+++ b/src/main/java/io/driver/codrive/global/auth/accessHandler/UserAccessHandler.java
@@ -1,0 +1,11 @@
+package io.driver.codrive.global.auth.accessHandler;
+
+import org.springframework.stereotype.Component;
+
+@Component
+public class UserAccessHandler implements EntityAccessHandler {
+	@Override
+	public boolean isOwner(Long userId) {
+		return isSameWithCurrentUserId(userId);
+	}
+}

--- a/src/main/java/io/driver/codrive/global/config/SecurityConfig.java
+++ b/src/main/java/io/driver/codrive/global/config/SecurityConfig.java
@@ -2,12 +2,13 @@ package io.driver.codrive.global.config;
 
 import java.util.List;
 
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Configuration;
 
 import io.driver.codrive.global.constants.APIConstants;
-import io.driver.codrive.global.jwt.JwtProvider;
+import io.driver.codrive.global.auth.JwtProvider;
 import io.driver.codrive.global.util.JsonUtils;
-import io.driver.codrive.global.jwt.JwtAuthenticationFilter;
+import io.driver.codrive.global.auth.JwtAuthenticationFilter;
 import io.driver.codrive.global.model.ErrorResponse;
 import lombok.extern.slf4j.Slf4j;
 
@@ -28,6 +29,9 @@ import org.springframework.web.cors.CorsConfigurationSource;
 @Slf4j
 @EnableWebSecurity
 public class SecurityConfig {
+    @Value("${spring.security.debug:false}")
+    boolean webSecurityDebug;
+
     private static final String[] WHITELIST = new String[] {
 			"/",
             APIConstants.API_PREFIX + "/auth/**",
@@ -58,7 +62,7 @@ public class SecurityConfig {
                     response.setStatus(HttpStatus.UNAUTHORIZED.value());
                     response.setContentType(MediaType.APPLICATION_JSON_VALUE);
                     response.getWriter().write(JsonUtils.serialize(
-						ErrorResponse.of(HttpStatus.UNAUTHORIZED.value(), "Unauthroized Request", null)));
+						ErrorResponse.of(HttpStatus.UNAUTHORIZED.value(), "Unauthorized Request", null)));
                 });
 
                 e.accessDeniedHandler((request, response, ex) -> {

--- a/src/main/java/io/driver/codrive/global/config/WebMvcConfig.java
+++ b/src/main/java/io/driver/codrive/global/config/WebMvcConfig.java
@@ -1,0 +1,24 @@
+package io.driver.codrive.global.config;
+
+
+import java.util.List;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import io.driver.codrive.global.auth.AuthenticatedUserArgumentResolver;
+import io.driver.codrive.modules.user.service.UserService;
+import lombok.RequiredArgsConstructor;
+
+@Configuration
+@RequiredArgsConstructor
+public class WebMvcConfig implements WebMvcConfigurer {
+
+	private final UserService userService;
+
+    @Override
+    public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
+		resolvers.add(new AuthenticatedUserArgumentResolver(userService));
+	}
+}

--- a/src/main/java/io/driver/codrive/global/config/WebMvcConfig.java
+++ b/src/main/java/io/driver/codrive/global/config/WebMvcConfig.java
@@ -8,6 +8,7 @@ import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 import io.driver.codrive.global.auth.AuthenticatedUserArgumentResolver;
+import io.driver.codrive.global.auth.AuthenticatedUserIdArgumentResolver;
 import io.driver.codrive.modules.user.service.UserService;
 import lombok.RequiredArgsConstructor;
 
@@ -20,5 +21,6 @@ public class WebMvcConfig implements WebMvcConfigurer {
     @Override
     public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
 		resolvers.add(new AuthenticatedUserArgumentResolver(userService));
+		resolvers.add(new AuthenticatedUserIdArgumentResolver());
 	}
 }

--- a/src/main/java/io/driver/codrive/global/entity/BaseEntity.java
+++ b/src/main/java/io/driver/codrive/global/entity/BaseEntity.java
@@ -11,7 +11,7 @@ import lombok.Getter;
 
 @Getter
 @MappedSuperclass
-public abstract class BaseEntity implements OwnedEntity {
+public abstract class BaseEntity {
     @CreationTimestamp
     @Column(nullable = false)
     private LocalDateTime createdAt;

--- a/src/main/java/io/driver/codrive/global/entity/OwnedEntity.java
+++ b/src/main/java/io/driver/codrive/global/entity/OwnedEntity.java
@@ -1,5 +1,0 @@
-package io.driver.codrive.global.entity;
-
-public interface OwnedEntity {
-    Long getOwnerId();
-}

--- a/src/main/java/io/driver/codrive/global/exception/ForbiddenApplcationException.java
+++ b/src/main/java/io/driver/codrive/global/exception/ForbiddenApplcationException.java
@@ -1,7 +1,0 @@
-package io.driver.codrive.global.exception;
-
-public class ForbiddenApplcationException extends ApplicationException {
-	public ForbiddenApplcationException(String message) {
-		super(ErrorType.FORBIDDEN, message);
-	}
-}

--- a/src/main/java/io/driver/codrive/global/exception/ForbiddenApplicationException.java
+++ b/src/main/java/io/driver/codrive/global/exception/ForbiddenApplicationException.java
@@ -1,0 +1,7 @@
+package io.driver.codrive.global.exception;
+
+public class ForbiddenApplicationException extends ApplicationException {
+	public ForbiddenApplicationException(String message) {
+		super(ErrorType.FORBIDDEN, message);
+	}
+}

--- a/src/main/java/io/driver/codrive/global/exception/handler/GlobalExceptionHandler.java
+++ b/src/main/java/io/driver/codrive/global/exception/handler/GlobalExceptionHandler.java
@@ -3,14 +3,12 @@ package io.driver.codrive.global.exception.handler;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.hibernate.StaleStateException;
-import org.hibernate.dialect.lock.OptimisticEntityLockException;
 import org.springframework.dao.ConcurrencyFailureException;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.HttpStatusCode;
 import org.springframework.http.ResponseEntity;
-import org.springframework.orm.ObjectOptimisticLockingFailureException;
+import org.springframework.security.access.AccessDeniedException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
@@ -37,18 +35,28 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
 	public ResponseEntity<Object> handleMethodArgumentNotValid(MethodArgumentNotValidException ex, HttpHeaders headers, HttpStatusCode status, WebRequest request) {
         Map<String, Object> errorDetails = new HashMap<>();
         ex.getBindingResult().getFieldErrors().forEach(e -> errorDetails.put(e.getField(), e.getDefaultMessage()));
-        return new ResponseEntity<>(ErrorResponse.of(HttpStatus.BAD_REQUEST.value(), "잘못된 요청입니다.", errorDetails), HttpStatus.BAD_REQUEST);
+        return new ResponseEntity<>(ErrorResponse.of(HttpStatus.BAD_REQUEST.value(),
+			"잘못된 요청입니다.", errorDetails), HttpStatus.BAD_REQUEST);
+    }
+
+    @ExceptionHandler(AccessDeniedException.class)
+    public ResponseEntity<ErrorResponse> handleException(AccessDeniedException e, HttpServletRequest request) {
+        log.error("Request: {} {}, AccessDeniedException: {}", request.getMethod(), request.getRequestURI(), e.getMessage(), e);
+        return new ResponseEntity<>(ErrorResponse.of(HttpStatus.FORBIDDEN.value(),
+			"해당 리소스에 접근할 수 없습니다.", null), HttpStatus.FORBIDDEN);
     }
 
     @ExceptionHandler(Exception.class)
     public ResponseEntity<ErrorResponse> handleException(Exception e, HttpServletRequest request) {
         log.error("Request: {} {}, Exception: {}", request.getMethod(), request.getRequestURI(), e.getMessage(), e);
-        return new ResponseEntity<>(ErrorResponse.of(HttpStatus.INTERNAL_SERVER_ERROR.value(), e.getMessage(), null), HttpStatus.INTERNAL_SERVER_ERROR);
+        return new ResponseEntity<>(ErrorResponse.of(HttpStatus.INTERNAL_SERVER_ERROR.value(),
+			e.getMessage(), null), HttpStatus.INTERNAL_SERVER_ERROR);
     }
 
     @ExceptionHandler(ConcurrencyFailureException.class)
     public ResponseEntity<ErrorResponse> handleStaleStateException(ConcurrencyFailureException e, HttpServletRequest request) {
         log.error("Request: {} {}, ConcurrencyFailureException: {}", request.getMethod(), request.getRequestURI(), e.getMessage(), e);
-        return new ResponseEntity<>(ErrorResponse.of(HttpStatus.INTERNAL_SERVER_ERROR.value(), "요청을 처리할 수 없습니다.", null), HttpStatus.INTERNAL_SERVER_ERROR);
+        return new ResponseEntity<>(ErrorResponse.of(HttpStatus.INTERNAL_SERVER_ERROR.value(),
+			"요청을 처리할 수 없습니다.", null), HttpStatus.INTERNAL_SERVER_ERROR);
     }
 }

--- a/src/main/java/io/driver/codrive/global/util/AuthUtils.java
+++ b/src/main/java/io/driver/codrive/global/util/AuthUtils.java
@@ -6,7 +6,7 @@ import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 
 import io.driver.codrive.global.entity.OwnedEntity;
-import io.driver.codrive.global.exception.ForbiddenApplcationException;
+import io.driver.codrive.global.exception.ForbiddenApplicationException;
 import lombok.experimental.UtilityClass;
 
 @UtilityClass
@@ -25,7 +25,7 @@ public class AuthUtils {
 
     public void checkOwnedEntity(OwnedEntity entity) {
         if (!isOwnedEntity(entity)) {
-            throw new ForbiddenApplcationException("해당 리소스에 대한 권한이 없습니다.");
+            throw new ForbiddenApplicationException("해당 리소스에 대한 권한이 없습니다.");
         }
     }
 }

--- a/src/main/java/io/driver/codrive/global/util/AuthUtils.java
+++ b/src/main/java/io/driver/codrive/global/util/AuthUtils.java
@@ -1,12 +1,8 @@
 package io.driver.codrive.global.util;
 
-import java.util.Objects;
-
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 
-import io.driver.codrive.global.entity.OwnedEntity;
-import io.driver.codrive.global.exception.ForbiddenApplicationException;
 import lombok.experimental.UtilityClass;
 
 @UtilityClass
@@ -18,14 +14,4 @@ public class AuthUtils {
 		}
 		return Long.valueOf(authentication.getPrincipal().toString());
 	}
-
-    private boolean isOwnedEntity(OwnedEntity entity) {
-        return Objects.equals(entity.getOwnerId(), getCurrentUserId());
-    }
-
-    public void checkOwnedEntity(OwnedEntity entity) {
-        if (!isOwnedEntity(entity)) {
-            throw new ForbiddenApplicationException("해당 리소스에 대한 권한이 없습니다.");
-        }
-    }
 }

--- a/src/main/java/io/driver/codrive/modules/auth/service/AppTokenService.java
+++ b/src/main/java/io/driver/codrive/modules/auth/service/AppTokenService.java
@@ -4,7 +4,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import io.driver.codrive.global.exception.UnauthorizedApplicationException;
-import io.driver.codrive.global.jwt.JwtProvider;
+import io.driver.codrive.global.auth.JwtProvider;
 import io.driver.codrive.global.token.AppToken;
 import io.driver.codrive.global.token.AppTokenRepository;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/io/driver/codrive/modules/codeblock/domain/Codeblock.java
+++ b/src/main/java/io/driver/codrive/modules/codeblock/domain/Codeblock.java
@@ -27,9 +27,4 @@ public class Codeblock extends BaseEntity {
 	@ManyToOne
 	@JoinColumn(name = "record_id", nullable = false)
 	private Record record;
-
-	@Override
-	public Long getOwnerId() {
-		return this.record.getOwnerId();
-	}
 }

--- a/src/main/java/io/driver/codrive/modules/follow/controller/FollowController.java
+++ b/src/main/java/io/driver/codrive/modules/follow/controller/FollowController.java
@@ -3,7 +3,7 @@ package io.driver.codrive.modules.follow.controller;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
-import io.driver.codrive.global.auth.AuthenticatedUser;
+import io.driver.codrive.global.auth.AuthenticatedUserId;
 import io.driver.codrive.global.model.SortType;
 import io.driver.codrive.modules.follow.model.response.FollowingSummaryListResponse;
 import io.driver.codrive.modules.follow.model.response.FollowingWeeklyCountResponse;
@@ -12,7 +12,6 @@ import io.driver.codrive.modules.follow.model.response.WeeklyFollowingResponse;
 import io.driver.codrive.modules.follow.service.FollowService;
 import io.driver.codrive.global.constants.APIConstants;
 import io.driver.codrive.global.model.BaseResponse;
-import io.driver.codrive.modules.user.domain.User;
 import io.driver.codrive.modules.user.model.response.UserListResponse;
 import io.driver.codrive.modules.user.model.response.UserSummaryResponse;
 import io.swagger.v3.oas.annotations.Operation;
@@ -45,8 +44,8 @@ public class FollowController {
 		}
 	)
 	@PostMapping("/{nickname}")
-	public ResponseEntity<BaseResponse<Void>> follow(@AuthenticatedUser User currentUser, @PathVariable(name = "nickname") String nickname) {
-		followService.follow(currentUser.getUserId(), nickname);
+	public ResponseEntity<BaseResponse<Void>> follow(@AuthenticatedUserId Long currentUserId, @PathVariable(name = "nickname") String nickname) {
+		followService.follow(currentUserId, nickname);
 		return ResponseEntity.ok(BaseResponse.of(null));
 	}
 
@@ -62,8 +61,8 @@ public class FollowController {
 		}
 	)
 	@DeleteMapping("/{nickname}")
-	public ResponseEntity<BaseResponse<Void>> cancelFollow(@AuthenticatedUser User currentUser, @PathVariable(name = "nickname") String nickname) {
-		followService.cancelFollow(currentUser.getUserId(), nickname);
+	public ResponseEntity<BaseResponse<Void>> cancelFollow(@AuthenticatedUserId Long currentUserId, @PathVariable(name = "nickname") String nickname) {
+		followService.cancelFollow(currentUserId, nickname);
 		return ResponseEntity.ok(BaseResponse.of(null));
 	}
 
@@ -75,8 +74,8 @@ public class FollowController {
 		}
 	)
 	@GetMapping("/recommend")
-	public ResponseEntity<BaseResponse<UserListResponse>> getRandomUsers(@AuthenticatedUser User currentUser) {
-		UserListResponse response = followService.getRandomUsers(currentUser.getUserId());
+	public ResponseEntity<BaseResponse<UserListResponse>> getRandomUsers(@AuthenticatedUserId Long currentUserId) {
+		UserListResponse response = followService.getRandomUsers(currentUserId);
 		return ResponseEntity.ok(BaseResponse.of(response));
 	}
 
@@ -88,8 +87,8 @@ public class FollowController {
 		}
 	)
 	@GetMapping("/followings/weekly-count")
-	public ResponseEntity<BaseResponse<FollowingWeeklyCountResponse>> getFollowingsWeeklyCount(@AuthenticatedUser User currentUser) {
-		FollowingWeeklyCountResponse response = followService.getFollowingsWeeklyCount(currentUser.getUserId());
+	public ResponseEntity<BaseResponse<FollowingWeeklyCountResponse>> getFollowingsWeeklyCount(@AuthenticatedUserId Long currentUserId) {
+		FollowingWeeklyCountResponse response = followService.getFollowingsWeeklyCount(currentUserId);
 		return ResponseEntity.ok(BaseResponse.of(response));
 	}
 
@@ -101,8 +100,8 @@ public class FollowController {
 		}
 	)
 	@GetMapping("/followings/today-solved")
-	public ResponseEntity<BaseResponse<TodaySolvedFollowingResponse>> getTodaySolvedFollowings(@AuthenticatedUser User currentUser) {
-		TodaySolvedFollowingResponse response = followService.getTodaySolvedFollowings(currentUser.getUserId());
+	public ResponseEntity<BaseResponse<TodaySolvedFollowingResponse>> getTodaySolvedFollowings(@AuthenticatedUserId Long currentUserId) {
+		TodaySolvedFollowingResponse response = followService.getTodaySolvedFollowings(currentUserId);
 		return ResponseEntity.ok(BaseResponse.of(response));
 	}
 
@@ -114,8 +113,8 @@ public class FollowController {
 		}
 	)
 	@GetMapping("/followings/weekly")
-	public ResponseEntity<BaseResponse<WeeklyFollowingResponse>> getWeeklyFollowings(@AuthenticatedUser User currentUser) {
-		WeeklyFollowingResponse response = followService.getWeeklyFollowings(currentUser.getUserId());
+	public ResponseEntity<BaseResponse<WeeklyFollowingResponse>> getWeeklyFollowings(@AuthenticatedUserId Long currentUserId) {
+		WeeklyFollowingResponse response = followService.getWeeklyFollowings(currentUserId);
 		return ResponseEntity.ok(BaseResponse.of(response));
 	}
 
@@ -134,11 +133,11 @@ public class FollowController {
 	)
 	@GetMapping("/followings/summary/{sortType}")
 	public ResponseEntity<BaseResponse<FollowingSummaryListResponse>> getFollowingsSummary(
-		@AuthenticatedUser User currentUser,
+		@AuthenticatedUserId Long currentUserId,
 		@PathVariable(name = "sortType") SortType sortType,
 		@RequestParam(name = "page", defaultValue = "0") Integer page,
 		@RequestParam(name = "roomId", required = false) Long roomId) {
-		FollowingSummaryListResponse response = followService.getFollowingsSummary(currentUser.getUserId(), sortType, page, roomId);
+		FollowingSummaryListResponse response = followService.getFollowingsSummary(currentUserId, sortType, page, roomId);
 		return ResponseEntity.ok(BaseResponse.of(response));
 	}
 

--- a/src/main/java/io/driver/codrive/modules/follow/controller/FollowController.java
+++ b/src/main/java/io/driver/codrive/modules/follow/controller/FollowController.java
@@ -3,6 +3,7 @@ package io.driver.codrive.modules.follow.controller;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import io.driver.codrive.global.auth.AuthenticatedUser;
 import io.driver.codrive.global.model.SortType;
 import io.driver.codrive.modules.follow.model.response.FollowingSummaryListResponse;
 import io.driver.codrive.modules.follow.model.response.FollowingWeeklyCountResponse;
@@ -11,6 +12,7 @@ import io.driver.codrive.modules.follow.model.response.WeeklyFollowingResponse;
 import io.driver.codrive.modules.follow.service.FollowService;
 import io.driver.codrive.global.constants.APIConstants;
 import io.driver.codrive.global.model.BaseResponse;
+import io.driver.codrive.modules.user.domain.User;
 import io.driver.codrive.modules.user.model.response.UserListResponse;
 import io.driver.codrive.modules.user.model.response.UserSummaryResponse;
 import io.swagger.v3.oas.annotations.Operation;
@@ -43,8 +45,8 @@ public class FollowController {
 		}
 	)
 	@PostMapping("/{nickname}")
-	public ResponseEntity<BaseResponse<Void>> follow(@PathVariable(name = "nickname") String nickname) {
-		followService.follow(nickname);
+	public ResponseEntity<BaseResponse<Void>> follow(@AuthenticatedUser User currentUser, @PathVariable(name = "nickname") String nickname) {
+		followService.follow(currentUser.getUserId(), nickname);
 		return ResponseEntity.ok(BaseResponse.of(null));
 	}
 
@@ -60,8 +62,8 @@ public class FollowController {
 		}
 	)
 	@DeleteMapping("/{nickname}")
-	public ResponseEntity<BaseResponse<Void>> cancelFollow(@PathVariable(name = "nickname") String nickname) {
-		followService.cancelFollow(nickname);
+	public ResponseEntity<BaseResponse<Void>> cancelFollow(@AuthenticatedUser User currentUser, @PathVariable(name = "nickname") String nickname) {
+		followService.cancelFollow(currentUser.getUserId(), nickname);
 		return ResponseEntity.ok(BaseResponse.of(null));
 	}
 
@@ -73,8 +75,8 @@ public class FollowController {
 		}
 	)
 	@GetMapping("/recommend")
-	public ResponseEntity<BaseResponse<UserListResponse>> getRandomUsers() {
-		UserListResponse response = followService.getRandomUsers();
+	public ResponseEntity<BaseResponse<UserListResponse>> getRandomUsers(@AuthenticatedUser User currentUser) {
+		UserListResponse response = followService.getRandomUsers(currentUser.getUserId());
 		return ResponseEntity.ok(BaseResponse.of(response));
 	}
 
@@ -86,8 +88,8 @@ public class FollowController {
 		}
 	)
 	@GetMapping("/followings/weekly-count")
-	public ResponseEntity<BaseResponse<FollowingWeeklyCountResponse>> getFollowingsWeeklyCount() {
-		FollowingWeeklyCountResponse response = followService.getFollowingsWeeklyCount();
+	public ResponseEntity<BaseResponse<FollowingWeeklyCountResponse>> getFollowingsWeeklyCount(@AuthenticatedUser User currentUser) {
+		FollowingWeeklyCountResponse response = followService.getFollowingsWeeklyCount(currentUser.getUserId());
 		return ResponseEntity.ok(BaseResponse.of(response));
 	}
 
@@ -99,8 +101,8 @@ public class FollowController {
 		}
 	)
 	@GetMapping("/followings/today-solved")
-	public ResponseEntity<BaseResponse<TodaySolvedFollowingResponse>> getTodaySolvedFollowings() {
-		TodaySolvedFollowingResponse response = followService.getTodaySolvedFollowings();
+	public ResponseEntity<BaseResponse<TodaySolvedFollowingResponse>> getTodaySolvedFollowings(@AuthenticatedUser User currentUser) {
+		TodaySolvedFollowingResponse response = followService.getTodaySolvedFollowings(currentUser.getUserId());
 		return ResponseEntity.ok(BaseResponse.of(response));
 	}
 
@@ -112,8 +114,8 @@ public class FollowController {
 		}
 	)
 	@GetMapping("/followings/weekly")
-	public ResponseEntity<BaseResponse<WeeklyFollowingResponse>> getWeeklyFollowings() {
-		WeeklyFollowingResponse response = followService.getWeeklyFollowings();
+	public ResponseEntity<BaseResponse<WeeklyFollowingResponse>> getWeeklyFollowings(@AuthenticatedUser User currentUser) {
+		WeeklyFollowingResponse response = followService.getWeeklyFollowings(currentUser.getUserId());
 		return ResponseEntity.ok(BaseResponse.of(response));
 	}
 
@@ -132,10 +134,11 @@ public class FollowController {
 	)
 	@GetMapping("/followings/summary/{sortType}")
 	public ResponseEntity<BaseResponse<FollowingSummaryListResponse>> getFollowingsSummary(
+		@AuthenticatedUser User currentUser,
 		@PathVariable(name = "sortType") SortType sortType,
 		@RequestParam(name = "page", defaultValue = "0") Integer page,
 		@RequestParam(name = "roomId", required = false) Long roomId) {
-		FollowingSummaryListResponse response = followService.getFollowingsSummary(sortType, page, roomId);
+		FollowingSummaryListResponse response = followService.getFollowingsSummary(currentUser.getUserId(), sortType, page, roomId);
 		return ResponseEntity.ok(BaseResponse.of(response));
 	}
 

--- a/src/main/java/io/driver/codrive/modules/follow/controller/FollowController.java
+++ b/src/main/java/io/driver/codrive/modules/follow/controller/FollowController.java
@@ -44,7 +44,8 @@ public class FollowController {
 		}
 	)
 	@PostMapping("/{nickname}")
-	public ResponseEntity<BaseResponse<Void>> follow(@AuthenticatedUserId Long currentUserId, @PathVariable(name = "nickname") String nickname) {
+	public ResponseEntity<BaseResponse<Void>> follow(@Parameter(hidden = true) @AuthenticatedUserId Long currentUserId,
+		@PathVariable(name = "nickname") String nickname) {
 		followService.follow(currentUserId, nickname);
 		return ResponseEntity.ok(BaseResponse.of(null));
 	}
@@ -61,7 +62,9 @@ public class FollowController {
 		}
 	)
 	@DeleteMapping("/{nickname}")
-	public ResponseEntity<BaseResponse<Void>> cancelFollow(@AuthenticatedUserId Long currentUserId, @PathVariable(name = "nickname") String nickname) {
+	public ResponseEntity<BaseResponse<Void>> cancelFollow(
+		@Parameter(hidden = true) @AuthenticatedUserId Long currentUserId,
+		@PathVariable(name = "nickname") String nickname) {
 		followService.cancelFollow(currentUserId, nickname);
 		return ResponseEntity.ok(BaseResponse.of(null));
 	}
@@ -74,7 +77,8 @@ public class FollowController {
 		}
 	)
 	@GetMapping("/recommend")
-	public ResponseEntity<BaseResponse<UserListResponse>> getRandomUsers(@AuthenticatedUserId Long currentUserId) {
+	public ResponseEntity<BaseResponse<UserListResponse>> getRandomUsers(
+		@Parameter(hidden = true) @AuthenticatedUserId Long currentUserId) {
 		UserListResponse response = followService.getRandomUsers(currentUserId);
 		return ResponseEntity.ok(BaseResponse.of(response));
 	}
@@ -87,7 +91,8 @@ public class FollowController {
 		}
 	)
 	@GetMapping("/followings/weekly-count")
-	public ResponseEntity<BaseResponse<FollowingWeeklyCountResponse>> getFollowingsWeeklyCount(@AuthenticatedUserId Long currentUserId) {
+	public ResponseEntity<BaseResponse<FollowingWeeklyCountResponse>> getFollowingsWeeklyCount(
+		@Parameter(hidden = true) @AuthenticatedUserId Long currentUserId) {
 		FollowingWeeklyCountResponse response = followService.getFollowingsWeeklyCount(currentUserId);
 		return ResponseEntity.ok(BaseResponse.of(response));
 	}
@@ -100,7 +105,8 @@ public class FollowController {
 		}
 	)
 	@GetMapping("/followings/today-solved")
-	public ResponseEntity<BaseResponse<TodaySolvedFollowingResponse>> getTodaySolvedFollowings(@AuthenticatedUserId Long currentUserId) {
+	public ResponseEntity<BaseResponse<TodaySolvedFollowingResponse>> getTodaySolvedFollowings(
+		@Parameter(hidden = true) @AuthenticatedUserId Long currentUserId) {
 		TodaySolvedFollowingResponse response = followService.getTodaySolvedFollowings(currentUserId);
 		return ResponseEntity.ok(BaseResponse.of(response));
 	}
@@ -113,7 +119,8 @@ public class FollowController {
 		}
 	)
 	@GetMapping("/followings/weekly")
-	public ResponseEntity<BaseResponse<WeeklyFollowingResponse>> getWeeklyFollowings(@AuthenticatedUserId Long currentUserId) {
+	public ResponseEntity<BaseResponse<WeeklyFollowingResponse>> getWeeklyFollowings(
+		@Parameter(hidden = true) @AuthenticatedUserId Long currentUserId) {
 		WeeklyFollowingResponse response = followService.getWeeklyFollowings(currentUserId);
 		return ResponseEntity.ok(BaseResponse.of(response));
 	}
@@ -133,7 +140,7 @@ public class FollowController {
 	)
 	@GetMapping("/followings/summary/{sortType}")
 	public ResponseEntity<BaseResponse<FollowingSummaryListResponse>> getFollowingsSummary(
-		@AuthenticatedUserId Long currentUserId,
+		@Parameter(hidden = true) @AuthenticatedUserId Long currentUserId,
 		@PathVariable(name = "sortType") SortType sortType,
 		@RequestParam(name = "page", defaultValue = "0") Integer page,
 		@RequestParam(name = "roomId", required = false) Long roomId) {

--- a/src/main/java/io/driver/codrive/modules/follow/domain/Follow.java
+++ b/src/main/java/io/driver/codrive/modules/follow/domain/Follow.java
@@ -32,10 +32,5 @@ public class Follow extends BaseEntity {
 			.follower(follower)
 			.build();
 	}
-
-	@Override
-	public Long getOwnerId() {
-		return null;
-	}
 }
 

--- a/src/main/java/io/driver/codrive/modules/mappings/recordCategoryMapping/domain/RecordCategoryMapping.java
+++ b/src/main/java/io/driver/codrive/modules/mappings/recordCategoryMapping/domain/RecordCategoryMapping.java
@@ -37,9 +37,4 @@ public class RecordCategoryMapping extends BaseEntity {
 	public String getCategoryName() {
 		return category.getName();
 	}
-
-	@Override
-	public Long getOwnerId() {
-		return this.record.getOwnerId();
-	}
 }

--- a/src/main/java/io/driver/codrive/modules/mappings/roomLanguageMapping/domain/RoomLanguageMapping.java
+++ b/src/main/java/io/driver/codrive/modules/mappings/roomLanguageMapping/domain/RoomLanguageMapping.java
@@ -37,9 +37,4 @@ public class RoomLanguageMapping extends BaseEntity {
 	public String getLanguageName() {
 		return language.getName();
 	}
-
-	@Override
-	public Long getOwnerId() {
-		return this.room.getOwnerId();
-	}
 }

--- a/src/main/java/io/driver/codrive/modules/mappings/roomUserMapping/domain/RoomUserMapping.java
+++ b/src/main/java/io/driver/codrive/modules/mappings/roomUserMapping/domain/RoomUserMapping.java
@@ -37,9 +37,4 @@ public class RoomUserMapping extends BaseEntity {
 	public boolean isOwner() {
 		return this.room.getOwner().getUserId().equals(this.user.getUserId());
 	}
-
-	@Override
-	public Long getOwnerId() {
-		return this.user.getUserId();
-	}
 }

--- a/src/main/java/io/driver/codrive/modules/mappings/roomUserMapping/service/RoomUserMappingService.java
+++ b/src/main/java/io/driver/codrive/modules/mappings/roomUserMapping/service/RoomUserMappingService.java
@@ -25,7 +25,6 @@ import lombok.RequiredArgsConstructor;
 public class RoomUserMappingService {
 	private final RoomUserMappingRepository roomUserMappingRepository;
 
-	@Transactional
 	public void createRoomUserMapping(Room room, User user) {
 		if (room.hasMember(user)) {
 			throw new IllegalArgumentApplicationException("이미 참여한 그룹입니다.");

--- a/src/main/java/io/driver/codrive/modules/notification/controller/NotificationController.java
+++ b/src/main/java/io/driver/codrive/modules/notification/controller/NotificationController.java
@@ -5,12 +5,14 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.http.codec.ServerSentEvent;
 import org.springframework.web.bind.annotation.*;
 
+import io.driver.codrive.global.auth.AuthenticatedUser;
 import io.driver.codrive.global.constants.APIConstants;
 import io.driver.codrive.global.model.BaseResponse;
 import io.driver.codrive.modules.notification.model.dto.NotificationEventDto;
 import io.driver.codrive.modules.notification.model.request.NotificationReadRequest;
 import io.driver.codrive.modules.notification.model.response.NotificationListResponse;
 import io.driver.codrive.modules.notification.service.NotificationService;
+import io.driver.codrive.modules.user.domain.User;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.ExampleObject;
@@ -30,16 +32,16 @@ public class NotificationController {
 		summary = "알림 스트림 등록"
 	)
 	@GetMapping(produces = MediaType.TEXT_EVENT_STREAM_VALUE)
-	public Flux<ServerSentEvent<NotificationEventDto>> registerUser() {
-		return notificationService.registerUser();
+	public Flux<ServerSentEvent<NotificationEventDto>> registerUser(@AuthenticatedUser User currentUser) {
+		return notificationService.registerUser(currentUser.getUserId());
 	}
 
 	@Operation(
 		summary = "알림 스트림 해제"
 	)
 	@DeleteMapping
-	public void unregisterUser() {
-		notificationService.unregisterUser();
+	public void unregisterUser(@AuthenticatedUser User currentUser) {
+		notificationService.unregisterUser(currentUser.getUserId());
 	}
 
 	@Operation(
@@ -50,8 +52,8 @@ public class NotificationController {
 		}
 	)
 	@GetMapping("/list")
-	public ResponseEntity<BaseResponse<NotificationListResponse>> getNotifications() {
-		NotificationListResponse response = notificationService.getNotifications();
+	public ResponseEntity<BaseResponse<NotificationListResponse>> getNotifications(@AuthenticatedUser User currentUser) {
+		NotificationListResponse response = notificationService.getNotifications(currentUser);
 		return ResponseEntity.ok(BaseResponse.of(response));
 	}
 

--- a/src/main/java/io/driver/codrive/modules/notification/controller/NotificationController.java
+++ b/src/main/java/io/driver/codrive/modules/notification/controller/NotificationController.java
@@ -6,6 +6,7 @@ import org.springframework.web.bind.annotation.*;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
 import io.driver.codrive.global.auth.AuthenticatedUser;
+import io.driver.codrive.global.auth.AuthenticatedUserId;
 import io.driver.codrive.global.constants.APIConstants;
 import io.driver.codrive.global.model.BaseResponse;
 import io.driver.codrive.modules.notification.model.request.NotificationReadRequest;
@@ -38,8 +39,8 @@ public class NotificationController {
 		summary = "알림 스트림 해제"
 	)
 	@DeleteMapping
-	public void unregisterUser(@AuthenticatedUser User currentUser) {
-		notificationService.unregisterUser(currentUser.getUserId());
+	public void unregisterUser(@AuthenticatedUserId Long currentUserId) {
+		notificationService.unregisterUser(currentUserId);
 	}
 
 	@Operation(

--- a/src/main/java/io/driver/codrive/modules/notification/domain/Notification.java
+++ b/src/main/java/io/driver/codrive/modules/notification/domain/Notification.java
@@ -28,11 +28,6 @@ public class Notification extends BaseEntity {
 
 	private Long dataId;
 
-	@Override
-	public Long getOwnerId() {
-		return user.getUserId();
-	}
-
 	public void changeIsRead(boolean isRead) {
 		this.isRead = isRead;
 	}

--- a/src/main/java/io/driver/codrive/modules/notification/service/NotificationDeleteService.java
+++ b/src/main/java/io/driver/codrive/modules/notification/service/NotificationDeleteService.java
@@ -21,15 +21,18 @@ public class NotificationDeleteService {
 	private static final int UNREAD_NOTIFICATIONS_CLEANUP_WEEKS = 8;
 	private final NotificationRepository notificationRepository;
 
-	@Transactional
-	public void deleteFollowNotifications(User user) {
+	public void deleteUserDataNotifications(User user) {
+		deleteFollowNotifications(user);
+		deleteRoomNotifications(user);
+	}
+
+	private void deleteFollowNotifications(User user) {
 		Long userId = user.getUserId();
 		List<Notification> followNotifications = notificationRepository.findAllByDataId(userId);
 		notificationRepository.deleteAll(followNotifications);
 	}
 
-	@Transactional
-	public void deleteRoomNotifications(User user) {
+	private void deleteRoomNotifications(User user) {
 		List<Room> createdRooms = user.getCreatedRooms();
 		List<Notification> roomNotifications = notificationRepository.findAllByDataIdIn(
 			createdRooms.stream().map(Room::getRoomId).toList());

--- a/src/main/java/io/driver/codrive/modules/notification/service/NotificationService.java
+++ b/src/main/java/io/driver/codrive/modules/notification/service/NotificationService.java
@@ -11,7 +11,6 @@ import org.springframework.transaction.annotation.Transactional;
 
 import io.driver.codrive.global.exception.InternalServerErrorApplicationException;
 import io.driver.codrive.global.exception.NotFoundApplicationException;
-import io.driver.codrive.global.util.AuthUtils;
 import io.driver.codrive.modules.notification.domain.Notification;
 import io.driver.codrive.modules.notification.domain.NotificationRepository;
 import io.driver.codrive.modules.notification.domain.NotificationType;
@@ -34,8 +33,7 @@ public class NotificationService {
 	private final Map<Long, Sinks.Many<ServerSentEvent<NotificationEventDto>>> userNotificationSinks = new ConcurrentHashMap<>();
 
 	@Transactional
-	public Flux<ServerSentEvent<NotificationEventDto>> registerUser() {
-		Long userId = AuthUtils.getCurrentUserId();
+	public Flux<ServerSentEvent<NotificationEventDto>> registerUser(Long userId) {
 		User user = userService.getUserById(userId);
 		Notification notification = Notification.create(user, null, NotificationType.CONNECT_START,
 			String.valueOf(userId));
@@ -79,8 +77,7 @@ public class NotificationService {
 			.build();
 	}
 
-	public void unregisterUser() {
-		Long userId = AuthUtils.getCurrentUserId();
+	public void unregisterUser(Long userId) {
 		if (userNotificationSinks.containsKey(userId)) {
 			userNotificationSinks.get(userId).tryEmitComplete();
 			userNotificationSinks.remove(userId);
@@ -90,8 +87,7 @@ public class NotificationService {
 		}
 	}
 
-	public NotificationListResponse getNotifications() {
-		User user = userService.getUserById(AuthUtils.getCurrentUserId());
+	public NotificationListResponse getNotifications(User user) {
 		List<Notification> notifications = notificationRepository.findByUserOrderByCreatedAtDesc(user);
 		return NotificationListResponse.of(notifications);
 	}

--- a/src/main/java/io/driver/codrive/modules/record/controller/RecordBoardController.java
+++ b/src/main/java/io/driver/codrive/modules/record/controller/RecordBoardController.java
@@ -3,7 +3,7 @@ package io.driver.codrive.modules.record.controller;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
-import io.driver.codrive.global.auth.AuthenticatedUser;
+import io.driver.codrive.global.auth.AuthenticatedUserId;
 import io.driver.codrive.global.constants.APIConstants;
 import io.driver.codrive.global.model.BaseResponse;
 import io.driver.codrive.global.model.SortType;
@@ -11,7 +11,6 @@ import io.driver.codrive.modules.record.model.response.BoardResponse;
 import io.driver.codrive.modules.record.model.response.RecordMonthListResponse;
 import io.driver.codrive.modules.record.model.response.UnsolvedMonthResponse;
 import io.driver.codrive.modules.record.service.CountBoardService;
-import io.driver.codrive.modules.user.domain.User;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.enums.ParameterIn;
@@ -51,9 +50,9 @@ public class RecordBoardController {
 		@RequestParam(name = "pivotDate", required = false) String pivotDate,
 		@RequestParam(name = "page", defaultValue = "0") Integer page,
 		@RequestParam(name = "size", defaultValue = "7") Integer size,
-		@AuthenticatedUser User currentUser) {
+		@AuthenticatedUserId Long currentUserId) {
 		RecordMonthListResponse response = countBoardService.getRecordsByMonth(userId, sortType, pivotDate,
-			page, size, currentUser.getUserId());
+			page, size, currentUserId);
 		return ResponseEntity.ok(BaseResponse.of(response));
 	}
 

--- a/src/main/java/io/driver/codrive/modules/record/controller/RecordBoardController.java
+++ b/src/main/java/io/driver/codrive/modules/record/controller/RecordBoardController.java
@@ -3,6 +3,7 @@ package io.driver.codrive.modules.record.controller;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import io.driver.codrive.global.auth.AuthenticatedUser;
 import io.driver.codrive.global.constants.APIConstants;
 import io.driver.codrive.global.model.BaseResponse;
 import io.driver.codrive.global.model.SortType;
@@ -10,6 +11,7 @@ import io.driver.codrive.modules.record.model.response.BoardResponse;
 import io.driver.codrive.modules.record.model.response.RecordMonthListResponse;
 import io.driver.codrive.modules.record.model.response.UnsolvedMonthResponse;
 import io.driver.codrive.modules.record.service.CountBoardService;
+import io.driver.codrive.modules.user.domain.User;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.enums.ParameterIn;
@@ -48,8 +50,10 @@ public class RecordBoardController {
 		@PathVariable(name = "sortType") SortType sortType,
 		@RequestParam(name = "pivotDate", required = false) String pivotDate,
 		@RequestParam(name = "page", defaultValue = "0") Integer page,
-		@RequestParam(name = "size", defaultValue = "7") Integer size) {
-		RecordMonthListResponse response = countBoardService.getRecordsByMonth(userId, sortType, pivotDate, page, size);
+		@RequestParam(name = "size", defaultValue = "7") Integer size,
+		@AuthenticatedUser User currentUser) {
+		RecordMonthListResponse response = countBoardService.getRecordsByMonth(userId, sortType, pivotDate,
+			page, size, currentUser.getUserId());
 		return ResponseEntity.ok(BaseResponse.of(response));
 	}
 

--- a/src/main/java/io/driver/codrive/modules/record/controller/RecordController.java
+++ b/src/main/java/io/driver/codrive/modules/record/controller/RecordController.java
@@ -52,7 +52,7 @@ public class RecordController {
 		}
 	)
 	@PostMapping
-	public ResponseEntity<BaseResponse<RecordCreateResponse>> createSavedRecord(@AuthenticatedUserId Long currentUserId,
+	public ResponseEntity<BaseResponse<RecordCreateResponse>> createSavedRecord(@Parameter(hidden = true) @AuthenticatedUserId Long currentUserId,
 		@Valid @RequestBody RecordSaveRequest request) throws IOException {
 		RecordCreateResponse response = recordSaveService.createRecord(currentUserId, request);
 		return ResponseEntity.ok(BaseResponse.of(response));

--- a/src/main/java/io/driver/codrive/modules/record/controller/RecordController.java
+++ b/src/main/java/io/driver/codrive/modules/record/controller/RecordController.java
@@ -6,6 +6,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import io.driver.codrive.global.auth.AuthenticatedUser;
+import io.driver.codrive.global.auth.AuthenticatedUserId;
 import io.driver.codrive.global.constants.APIConstants;
 import io.driver.codrive.global.model.BaseResponse;
 import io.driver.codrive.modules.record.model.request.RecordModifyRequest;
@@ -51,9 +52,9 @@ public class RecordController {
 		}
 	)
 	@PostMapping
-	public ResponseEntity<BaseResponse<RecordCreateResponse>> createSavedRecord(@AuthenticatedUser User currentUser,
+	public ResponseEntity<BaseResponse<RecordCreateResponse>> createSavedRecord(@AuthenticatedUserId Long currentUserId,
 		@Valid @RequestBody RecordSaveRequest request) throws IOException {
-		RecordCreateResponse response = recordSaveService.createRecord(currentUser.getUserId(), request);
+		RecordCreateResponse response = recordSaveService.createRecord(currentUserId, request);
 		return ResponseEntity.ok(BaseResponse.of(response));
 	}
 
@@ -89,9 +90,9 @@ public class RecordController {
 		}
 	)
 	@PostMapping("/temp")
-	public ResponseEntity<BaseResponse<RecordCreateResponse>> createTempRecord(@AuthenticatedUser User currentUser,
+	public ResponseEntity<BaseResponse<RecordCreateResponse>> createTempRecord(@AuthenticatedUserId Long currentUserId,
 		@Valid @RequestBody RecordTempRequest request) throws IOException {
-		RecordCreateResponse response = recordTempService.createRecord(currentUser.getUserId(), request);
+		RecordCreateResponse response = recordTempService.createRecord(currentUserId, request);
 		return ResponseEntity.ok(BaseResponse.of(response));
 	}
 
@@ -136,10 +137,10 @@ public class RecordController {
 	)
 	@PatchMapping("/{recordId}")
 	public ResponseEntity<BaseResponse<RecordModifyResponse>> modifyRecord(
-		@AuthenticatedUser User currentUser,
+		@AuthenticatedUserId Long currentUserId,
 		@PathVariable(name = "recordId") Long recordId,
 		@Valid @RequestBody RecordModifyRequest request) throws IOException {
-		RecordModifyResponse response = recordService.modifyRecord(currentUser.getUserId(), recordId, request);
+		RecordModifyResponse response = recordService.modifyRecord(currentUserId, recordId, request);
 		return ResponseEntity.ok(BaseResponse.of(response));
 	}
 

--- a/src/main/java/io/driver/codrive/modules/record/controller/RecordController.java
+++ b/src/main/java/io/driver/codrive/modules/record/controller/RecordController.java
@@ -5,6 +5,7 @@ import java.io.IOException;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import io.driver.codrive.global.auth.AuthenticatedUser;
 import io.driver.codrive.global.constants.APIConstants;
 import io.driver.codrive.global.model.BaseResponse;
 import io.driver.codrive.modules.record.model.request.RecordModifyRequest;
@@ -13,6 +14,7 @@ import io.driver.codrive.modules.record.model.request.RecordTempRequest;
 import io.driver.codrive.modules.record.model.response.*;
 import io.driver.codrive.modules.record.service.RecordCreateService;
 import io.driver.codrive.modules.record.service.RecordService;
+import io.driver.codrive.modules.user.domain.User;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.enums.ParameterIn;
@@ -49,9 +51,9 @@ public class RecordController {
 		}
 	)
 	@PostMapping
-	public ResponseEntity<BaseResponse<RecordCreateResponse>> createSavedRecord(@Valid @RequestBody RecordSaveRequest request) throws
-		IOException {
-		RecordCreateResponse response = recordSaveService.createRecord(request);
+	public ResponseEntity<BaseResponse<RecordCreateResponse>> createSavedRecord(@AuthenticatedUser User currentUser,
+		@Valid @RequestBody RecordSaveRequest request) throws IOException {
+		RecordCreateResponse response = recordSaveService.createRecord(currentUser.getUserId(), request);
 		return ResponseEntity.ok(BaseResponse.of(response));
 	}
 
@@ -66,8 +68,7 @@ public class RecordController {
 		}
 	)
 	@GetMapping("/{recordId}")
-	public ResponseEntity<BaseResponse<RecordDetailResponse>> getRecordDetail(
-		@PathVariable(name = "recordId") Long recordId) {
+	public ResponseEntity<BaseResponse<RecordDetailResponse>> getRecordDetail(@PathVariable(name = "recordId") Long recordId) {
 		RecordDetailResponse response = recordService.getRecordDetail(recordId);
 		return ResponseEntity.ok(BaseResponse.of(response));
 	}
@@ -88,9 +89,9 @@ public class RecordController {
 		}
 	)
 	@PostMapping("/temp")
-	public ResponseEntity<BaseResponse<RecordCreateResponse>> createTempRecord(@Valid @RequestBody RecordTempRequest request) throws
-		IOException {
-		RecordCreateResponse response = recordTempService.createRecord(request);
+	public ResponseEntity<BaseResponse<RecordCreateResponse>> createTempRecord(@AuthenticatedUser User currentUser,
+		@Valid @RequestBody RecordTempRequest request) throws IOException {
+		RecordCreateResponse response = recordTempService.createRecord(currentUser.getUserId(), request);
 		return ResponseEntity.ok(BaseResponse.of(response));
 	}
 
@@ -107,9 +108,10 @@ public class RecordController {
 	)
 	@GetMapping("/temp")
 	public ResponseEntity<BaseResponse<TempRecordListResponse>> getTempRecords(
+		@AuthenticatedUser User currentUser,
 		@RequestParam(name = "page", defaultValue = "0") Integer page,
 		@RequestParam(name = "size", defaultValue = "1") Integer size) {
-		TempRecordListResponse response = recordService.getTempRecordsByPage(page, size);
+		TempRecordListResponse response = recordService.getTempRecordsByPage(currentUser, page, size);
 		return ResponseEntity.ok(BaseResponse.of(response));
 	}
 
@@ -134,9 +136,10 @@ public class RecordController {
 	)
 	@PatchMapping("/{recordId}")
 	public ResponseEntity<BaseResponse<RecordModifyResponse>> modifyRecord(
-		@PathVariable(name = "recordId") Long recordId, @Valid @RequestBody RecordModifyRequest request) throws
-		IOException {
-		RecordModifyResponse response = recordService.modifyRecord(recordId, request);
+		@AuthenticatedUser User currentUser,
+		@PathVariable(name = "recordId") Long recordId,
+		@Valid @RequestBody RecordModifyRequest request) throws IOException {
+		RecordModifyResponse response = recordService.modifyRecord(currentUser.getUserId(), recordId, request);
 		return ResponseEntity.ok(BaseResponse.of(response));
 	}
 

--- a/src/main/java/io/driver/codrive/modules/record/domain/Record.java
+++ b/src/main/java/io/driver/codrive/modules/record/domain/Record.java
@@ -109,9 +109,4 @@ public class Record extends BaseEntity {
 	public boolean isSaved() {
 		return recordStatus == RecordStatus.SAVED;
 	}
-
-	@Override
-	public Long getOwnerId() {
-		return this.user.getUserId();
-	}
 }

--- a/src/main/java/io/driver/codrive/modules/record/domain/RecordRepository.java
+++ b/src/main/java/io/driver/codrive/modules/record/domain/RecordRepository.java
@@ -6,6 +6,8 @@ import java.util.List;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import io.driver.codrive.modules.user.domain.User;
@@ -16,4 +18,7 @@ public interface RecordRepository extends JpaRepository<Record, Long>, RecordRep
 	Page<Record> findAllByUserAndRecordStatusOrderByCreatedAtDesc(User user, RecordStatus recordStatus, Pageable pageable);
 	List<Record> findAllByUserAndRecordStatusOrderByCreatedAtDesc(User user, RecordStatus recordStatus);
 	List<Record> findAllByUserAndRecordStatusAndCreatedAtBetween(User user, RecordStatus recordStatus, LocalDateTime startOfDay, LocalDateTime endOfDay);
+
+	@Query("SELECT r.user.userId FROM Record r WHERE r.recordId = :recordId")
+	Long findOwnerIdByRecordId(@Param("recordId") Long recordId);
 }

--- a/src/main/java/io/driver/codrive/modules/record/service/RecordCreateService.java
+++ b/src/main/java/io/driver/codrive/modules/record/service/RecordCreateService.java
@@ -5,7 +5,6 @@ import java.util.List;
 
 import org.springframework.transaction.annotation.Transactional;
 
-import io.driver.codrive.global.util.AuthUtils;
 import io.driver.codrive.modules.codeblock.domain.Codeblock;
 import io.driver.codrive.modules.codeblock.model.request.CodeblockCreateRequest;
 import io.driver.codrive.modules.codeblock.service.CodeblockService;
@@ -25,8 +24,8 @@ public abstract class RecordCreateService<T extends RecordCreateRequest> {
 	private final RecordCategoryMappingService recordCategoryMappingService;
 
 	@Transactional
-	public RecordCreateResponse createRecord(T recordRequest) throws IOException {
-		User user = userService.getUserById(AuthUtils.getCurrentUserId());
+	public RecordCreateResponse createRecord(Long userId, T recordRequest) throws IOException {
+		User user = userService.getUserById(userId);
 		Record createdRecord = saveRecord(recordRequest, user);
 
 		createCodeblocks(recordRequest.getCodeblocks(), createdRecord);

--- a/src/main/java/io/driver/codrive/modules/record/service/github/GithubTokenService.java
+++ b/src/main/java/io/driver/codrive/modules/record/service/github/GithubTokenService.java
@@ -10,7 +10,7 @@ import org.springframework.web.reactive.function.client.WebClientResponseExcepti
 import io.driver.codrive.global.exception.InternalServerErrorApplicationException;
 import io.driver.codrive.global.exception.NotFoundApplicationException;
 import io.driver.codrive.global.exception.UnauthorizedApplicationException;
-import io.driver.codrive.global.jwt.JwtProvider;
+import io.driver.codrive.global.auth.JwtProvider;
 import io.driver.codrive.global.token.GithubToken;
 import io.driver.codrive.global.token.GithubTokenRepository;
 import io.driver.codrive.modules.auth.model.dto.GithubCodeDto;
@@ -77,6 +77,10 @@ public class GithubTokenService {
 		return githubTokenRepository.findById(String.valueOf(userId)).orElseThrow(
 			() -> new NotFoundApplicationException("Github Token")
 		);
+	}
+
+	public String getGithubAccessToken(Long userId) {
+		return getGithubTokenByUserId(userId).getAccessToken();
 	}
 
 	private boolean validateGithubToken(String accessToken) {

--- a/src/main/java/io/driver/codrive/modules/room/controller/RoomController.java
+++ b/src/main/java/io/driver/codrive/modules/room/controller/RoomController.java
@@ -46,7 +46,8 @@ public class RoomController {
 		}
 	)
 	@PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
-	public ResponseEntity<BaseResponse<RoomCreateResponse>> createRoom(@AuthenticatedUserId Long currentUserId,
+	public ResponseEntity<BaseResponse<RoomCreateResponse>> createRoom(
+		@Parameter(hidden = true) @AuthenticatedUserId Long currentUserId,
 		@Valid @RequestPart(value = "request") RoomCreateRequest request,
 		@RequestPart(value = "imageFile", required = false) MultipartFile imageFile) throws IOException {
 		RoomCreateResponse response = roomService.createRoom(currentUserId, request, imageFile);
@@ -64,7 +65,8 @@ public class RoomController {
 		}
 	)
 	@GetMapping("/{roomId}")
-	public ResponseEntity<BaseResponse<RoomDetailResponse>> getRoomDetail(@AuthenticatedUser User currentUser, @PathVariable(name = "roomId") Long roomId) {
+	public ResponseEntity<BaseResponse<RoomDetailResponse>> getRoomDetail(
+		@Parameter(hidden = true) @AuthenticatedUser User currentUser, @PathVariable(name = "roomId") Long roomId) {
 		RoomDetailResponse response = roomService.getRoomDetail(currentUser, roomId);
 		return ResponseEntity.ok(BaseResponse.of(response));
 	}
@@ -80,7 +82,8 @@ public class RoomController {
 		}
 	)
 	@GetMapping("/{roomId}/join")
-	public ResponseEntity<BaseResponse<JoinedRoomInfoResponse>> getJoinedRoomInfo(@AuthenticatedUserId Long currentUserId,
+	public ResponseEntity<BaseResponse<JoinedRoomInfoResponse>> getJoinedRoomInfo(
+		@Parameter(hidden = true) @AuthenticatedUserId Long currentUserId,
 		@PathVariable(name = "roomId") Long roomId) {
 		JoinedRoomInfoResponse response = roomService.getJoinedRoomInfo(currentUserId, roomId);
 		return ResponseEntity.ok(BaseResponse.of(response));
@@ -231,7 +234,8 @@ public class RoomController {
 		}
 	)
 	@GetMapping("/search")
-	public ResponseEntity<BaseResponse<RoomListResponse>> searchRooms(@AuthenticatedUserId Long currentUserId,
+	public ResponseEntity<BaseResponse<RoomListResponse>> searchRooms(
+		@Parameter(hidden = true) @AuthenticatedUserId Long currentUserId,
 		@RequestParam(name = "keyword") String keyword,
 		@RequestParam(name = "page", defaultValue = "0") Integer page) {
 		RoomListResponse response = roomService.searchRooms(currentUserId, keyword, page);
@@ -251,7 +255,8 @@ public class RoomController {
 		}
 	)
 	@GetMapping("/filter/{sortType}")
-	public ResponseEntity<BaseResponse<RoomListResponse>> filterRooms(@AuthenticatedUserId Long currentUserId,
+	public ResponseEntity<BaseResponse<RoomListResponse>> filterRooms(
+		@Parameter(hidden = true) @AuthenticatedUserId Long currentUserId,
 		@PathVariable(name = "sortType") SortType sortType,
 		@Parameter RoomFilterRequest request,
 		@RequestParam(name = "page", defaultValue = "0") Integer page) {
@@ -266,7 +271,8 @@ public class RoomController {
 		}
 	)
 	@GetMapping("/recent")
-	public ResponseEntity<BaseResponse<RecentRoomResponse>> getRecentRooms(@AuthenticatedUserId Long currentUserId) {
+	public ResponseEntity<BaseResponse<RecentRoomResponse>> getRecentRooms(
+		@Parameter(hidden = true) @AuthenticatedUserId Long currentUserId) {
 		RecentRoomResponse response = roomService.getRecentRooms(currentUserId);
 		return ResponseEntity.ok(BaseResponse.of(response));
 	}

--- a/src/main/java/io/driver/codrive/modules/room/controller/RoomController.java
+++ b/src/main/java/io/driver/codrive/modules/room/controller/RoomController.java
@@ -8,6 +8,7 @@ import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
 import io.driver.codrive.global.auth.AuthenticatedUser;
+import io.driver.codrive.global.auth.AuthenticatedUserId;
 import io.driver.codrive.global.constants.APIConstants;
 import io.driver.codrive.global.model.BaseResponse;
 import io.driver.codrive.global.model.SortType;
@@ -45,10 +46,10 @@ public class RoomController {
 		}
 	)
 	@PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
-	public ResponseEntity<BaseResponse<RoomCreateResponse>> createRoom(@AuthenticatedUser User currentUser,
+	public ResponseEntity<BaseResponse<RoomCreateResponse>> createRoom(@AuthenticatedUserId Long currentUserId,
 		@Valid @RequestPart(value = "request") RoomCreateRequest request,
 		@RequestPart(value = "imageFile", required = false) MultipartFile imageFile) throws IOException {
-		RoomCreateResponse response = roomService.createRoom(currentUser.getUserId(), request, imageFile);
+		RoomCreateResponse response = roomService.createRoom(currentUserId, request, imageFile);
 		return ResponseEntity.ok(BaseResponse.of(response));
 	}
 
@@ -79,9 +80,9 @@ public class RoomController {
 		}
 	)
 	@GetMapping("/{roomId}/join")
-	public ResponseEntity<BaseResponse<JoinedRoomInfoResponse>> getJoinedRoomInfo(@AuthenticatedUser User currentUser,
+	public ResponseEntity<BaseResponse<JoinedRoomInfoResponse>> getJoinedRoomInfo(@AuthenticatedUserId Long currentUserId,
 		@PathVariable(name = "roomId") Long roomId) {
-		JoinedRoomInfoResponse response = roomService.getJoinedRoomInfo(currentUser.getUserId(), roomId);
+		JoinedRoomInfoResponse response = roomService.getJoinedRoomInfo(currentUserId, roomId);
 		return ResponseEntity.ok(BaseResponse.of(response));
 	}
 
@@ -230,10 +231,10 @@ public class RoomController {
 		}
 	)
 	@GetMapping("/search")
-	public ResponseEntity<BaseResponse<RoomListResponse>> searchRooms(@AuthenticatedUser User currentUser,
+	public ResponseEntity<BaseResponse<RoomListResponse>> searchRooms(@AuthenticatedUserId Long currentUserId,
 		@RequestParam(name = "keyword") String keyword,
 		@RequestParam(name = "page", defaultValue = "0") Integer page) {
-		RoomListResponse response = roomService.searchRooms(currentUser.getUserId(), keyword, page);
+		RoomListResponse response = roomService.searchRooms(currentUserId, keyword, page);
 		return ResponseEntity.ok(BaseResponse.of(response));
 	}
 
@@ -250,11 +251,11 @@ public class RoomController {
 		}
 	)
 	@GetMapping("/filter/{sortType}")
-	public ResponseEntity<BaseResponse<RoomListResponse>> filterRooms(@AuthenticatedUser User currentUser,
+	public ResponseEntity<BaseResponse<RoomListResponse>> filterRooms(@AuthenticatedUserId Long currentUserId,
 		@PathVariable(name = "sortType") SortType sortType,
 		@Parameter RoomFilterRequest request,
 		@RequestParam(name = "page", defaultValue = "0") Integer page) {
-		RoomListResponse response = roomService.filterRooms(currentUser.getUserId(), sortType, request, page);
+		RoomListResponse response = roomService.filterRooms(currentUserId, sortType, request, page);
 		return ResponseEntity.ok(BaseResponse.of(response));
 	}
 
@@ -265,8 +266,8 @@ public class RoomController {
 		}
 	)
 	@GetMapping("/recent")
-	public ResponseEntity<BaseResponse<RecentRoomResponse>> getRecentRooms(@AuthenticatedUser User currentUser) {
-		RecentRoomResponse response = roomService.getRecentRooms(currentUser.getUserId());
+	public ResponseEntity<BaseResponse<RecentRoomResponse>> getRecentRooms(@AuthenticatedUserId Long currentUserId) {
+		RecentRoomResponse response = roomService.getRecentRooms(currentUserId);
 		return ResponseEntity.ok(BaseResponse.of(response));
 	}
 

--- a/src/main/java/io/driver/codrive/modules/room/controller/RoomController.java
+++ b/src/main/java/io/driver/codrive/modules/room/controller/RoomController.java
@@ -7,6 +7,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
+import io.driver.codrive.global.auth.AuthenticatedUser;
 import io.driver.codrive.global.constants.APIConstants;
 import io.driver.codrive.global.model.BaseResponse;
 import io.driver.codrive.global.model.SortType;
@@ -17,6 +18,7 @@ import io.driver.codrive.modules.room.model.response.*;
 import io.driver.codrive.modules.room.service.RoomService;
 import io.driver.codrive.modules.room.model.response.CreatedRoomListResponse;
 import io.driver.codrive.modules.room.model.response.JoinedRoomListResponse;
+import io.driver.codrive.modules.user.domain.User;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.enums.ParameterIn;
@@ -43,10 +45,10 @@ public class RoomController {
 		}
 	)
 	@PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
-	public ResponseEntity<BaseResponse<RoomCreateResponse>> createRoom(
+	public ResponseEntity<BaseResponse<RoomCreateResponse>> createRoom(@AuthenticatedUser User currentUser,
 		@Valid @RequestPart(value = "request") RoomCreateRequest request,
 		@RequestPart(value = "imageFile", required = false) MultipartFile imageFile) throws IOException {
-		RoomCreateResponse response = roomService.createRoom(request, imageFile);
+		RoomCreateResponse response = roomService.createRoom(currentUser.getUserId(), request, imageFile);
 		return ResponseEntity.ok(BaseResponse.of(response));
 	}
 
@@ -61,8 +63,8 @@ public class RoomController {
 		}
 	)
 	@GetMapping("/{roomId}")
-	public ResponseEntity<BaseResponse<RoomDetailResponse>> getRoomDetail(@PathVariable(name = "roomId") Long roomId) {
-		RoomDetailResponse response = roomService.getRoomDetail(roomId);
+	public ResponseEntity<BaseResponse<RoomDetailResponse>> getRoomDetail(@AuthenticatedUser User currentUser, @PathVariable(name = "roomId") Long roomId) {
+		RoomDetailResponse response = roomService.getRoomDetail(currentUser, roomId);
 		return ResponseEntity.ok(BaseResponse.of(response));
 	}
 
@@ -77,8 +79,9 @@ public class RoomController {
 		}
 	)
 	@GetMapping("/{roomId}/join")
-	public ResponseEntity<BaseResponse<JoinedRoomInfoResponse>> getJoinedRoomInfo(@PathVariable(name = "roomId") Long roomId) {
-		JoinedRoomInfoResponse response = roomService.getJoinedRoomInfo(roomId);
+	public ResponseEntity<BaseResponse<JoinedRoomInfoResponse>> getJoinedRoomInfo(@AuthenticatedUser User currentUser,
+		@PathVariable(name = "roomId") Long roomId) {
+		JoinedRoomInfoResponse response = roomService.getJoinedRoomInfo(currentUser.getUserId(), roomId);
 		return ResponseEntity.ok(BaseResponse.of(response));
 	}
 
@@ -130,9 +133,10 @@ public class RoomController {
 	)
 	@GetMapping("/{userId}/member/{sortType}")
 	public ResponseEntity<BaseResponse<JoinedRoomListResponse>> getJoinedRoomList(@PathVariable(name = "userId") Long userId,
-		@PathVariable(name = "sortType") SortType sortType, @RequestParam(name = "page", required = false) Integer page,
+		@AuthenticatedUser User currentUser, @PathVariable(name = "sortType") SortType sortType,
+		@RequestParam(name = "page", required = false) Integer page,
 		@RequestParam(name = "status", required = false) String status) {
-		JoinedRoomListResponse response = roomService.getJoinedRoomList(userId, sortType, page, status);
+		JoinedRoomListResponse response = roomService.getJoinedRoomList(userId, currentUser, sortType, page, status);
 		return ResponseEntity.ok(BaseResponse.of(response));
 	}
 
@@ -209,8 +213,7 @@ public class RoomController {
 		}
 	)
 	@GetMapping("{userId}/recommend")
-	public ResponseEntity<BaseResponse<RoomRecommendResponse>> getRecommendRoomList(
-		@PathVariable(name = "userId") Long userId) {
+	public ResponseEntity<BaseResponse<RoomRecommendResponse>> getRecommendRoomList(@PathVariable(name = "userId") Long userId) {
 		RoomRecommendResponse response = roomService.getRecommendRoomRandomList(userId);
 		return ResponseEntity.ok(BaseResponse.of(response));
 	}
@@ -227,9 +230,10 @@ public class RoomController {
 		}
 	)
 	@GetMapping("/search")
-	public ResponseEntity<BaseResponse<RoomListResponse>> searchRooms(@RequestParam(name = "keyword") String keyword,
+	public ResponseEntity<BaseResponse<RoomListResponse>> searchRooms(@AuthenticatedUser User currentUser,
+		@RequestParam(name = "keyword") String keyword,
 		@RequestParam(name = "page", defaultValue = "0") Integer page) {
-		RoomListResponse response = roomService.searchRooms(keyword, page);
+		RoomListResponse response = roomService.searchRooms(currentUser.getUserId(), keyword, page);
 		return ResponseEntity.ok(BaseResponse.of(response));
 	}
 
@@ -246,10 +250,11 @@ public class RoomController {
 		}
 	)
 	@GetMapping("/filter/{sortType}")
-	public ResponseEntity<BaseResponse<RoomListResponse>> filterRooms(@PathVariable(name = "sortType") SortType sortType,
+	public ResponseEntity<BaseResponse<RoomListResponse>> filterRooms(@AuthenticatedUser User currentUser,
+		@PathVariable(name = "sortType") SortType sortType,
 		@Parameter RoomFilterRequest request,
 		@RequestParam(name = "page", defaultValue = "0") Integer page) {
-		RoomListResponse response = roomService.filterRooms(sortType, request, page);
+		RoomListResponse response = roomService.filterRooms(currentUser.getUserId(), sortType, request, page);
 		return ResponseEntity.ok(BaseResponse.of(response));
 	}
 
@@ -260,8 +265,8 @@ public class RoomController {
 		}
 	)
 	@GetMapping("/recent")
-	public ResponseEntity<BaseResponse<RecentRoomResponse>> getRecentRooms() {
-		RecentRoomResponse response = roomService.getRecentRooms();
+	public ResponseEntity<BaseResponse<RecentRoomResponse>> getRecentRooms(@AuthenticatedUser User currentUser) {
+		RecentRoomResponse response = roomService.getRecentRooms(currentUser.getUserId());
 		return ResponseEntity.ok(BaseResponse.of(response));
 	}
 

--- a/src/main/java/io/driver/codrive/modules/room/controller/RoomMemberController.java
+++ b/src/main/java/io/driver/codrive/modules/room/controller/RoomMemberController.java
@@ -42,7 +42,8 @@ public class RoomMemberController {
 		}
 	)
 	@GetMapping("/{roomId}/members/{sortType}")
-	public ResponseEntity<BaseResponse<RoomMembersResponse>> getRoomMembers(@AuthenticatedUserId Long currentUserId,
+	public ResponseEntity<BaseResponse<RoomMembersResponse>> getRoomMembers(
+		@Parameter(hidden = true) @AuthenticatedUserId Long currentUserId,
 		@PathVariable(name = "roomId") Long roomId,
 		@PathVariable(name = "sortType") SortType sortType,
 		@RequestParam(name = "page", defaultValue = "0") Integer page) {

--- a/src/main/java/io/driver/codrive/modules/room/controller/RoomMemberController.java
+++ b/src/main/java/io/driver/codrive/modules/room/controller/RoomMemberController.java
@@ -3,6 +3,7 @@ package io.driver.codrive.modules.room.controller;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import io.driver.codrive.global.auth.AuthenticatedUser;
 import io.driver.codrive.global.constants.APIConstants;
 import io.driver.codrive.global.model.BaseResponse;
 import io.driver.codrive.global.model.SortType;
@@ -10,6 +11,7 @@ import io.driver.codrive.modules.room.model.response.RoomMembersResponse;
 import io.driver.codrive.modules.room.model.response.RoomParticipantListResponse;
 import io.driver.codrive.modules.room.model.response.RoomRankResponse;
 import io.driver.codrive.modules.room.service.RoomMemberService;
+import io.driver.codrive.modules.user.domain.User;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.enums.ParameterIn;
@@ -41,10 +43,11 @@ public class RoomMemberController {
 		}
 	)
 	@GetMapping("/{roomId}/members/{sortType}")
-	public ResponseEntity<BaseResponse<RoomMembersResponse>> getRoomMembers(@PathVariable(name = "roomId") Long roomId,
+	public ResponseEntity<BaseResponse<RoomMembersResponse>> getRoomMembers(@AuthenticatedUser User currentUser,
+		@PathVariable(name = "roomId") Long roomId,
 		@PathVariable(name = "sortType") SortType sortType,
 		@RequestParam(name = "page", defaultValue = "0") Integer page) {
-		RoomMembersResponse response = roomMemberService.getRoomMembers(roomId, sortType, page);
+		RoomMembersResponse response = roomMemberService.getRoomMembers(currentUser.getUserId(), roomId, sortType, page);
 		return ResponseEntity.ok(BaseResponse.of(response));
 	}
 

--- a/src/main/java/io/driver/codrive/modules/room/controller/RoomMemberController.java
+++ b/src/main/java/io/driver/codrive/modules/room/controller/RoomMemberController.java
@@ -3,7 +3,7 @@ package io.driver.codrive.modules.room.controller;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
-import io.driver.codrive.global.auth.AuthenticatedUser;
+import io.driver.codrive.global.auth.AuthenticatedUserId;
 import io.driver.codrive.global.constants.APIConstants;
 import io.driver.codrive.global.model.BaseResponse;
 import io.driver.codrive.global.model.SortType;
@@ -11,7 +11,6 @@ import io.driver.codrive.modules.room.model.response.RoomMembersResponse;
 import io.driver.codrive.modules.room.model.response.RoomParticipantListResponse;
 import io.driver.codrive.modules.room.model.response.RoomRankResponse;
 import io.driver.codrive.modules.room.service.RoomMemberService;
-import io.driver.codrive.modules.user.domain.User;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.enums.ParameterIn;
@@ -43,11 +42,11 @@ public class RoomMemberController {
 		}
 	)
 	@GetMapping("/{roomId}/members/{sortType}")
-	public ResponseEntity<BaseResponse<RoomMembersResponse>> getRoomMembers(@AuthenticatedUser User currentUser,
+	public ResponseEntity<BaseResponse<RoomMembersResponse>> getRoomMembers(@AuthenticatedUserId Long currentUserId,
 		@PathVariable(name = "roomId") Long roomId,
 		@PathVariable(name = "sortType") SortType sortType,
 		@RequestParam(name = "page", defaultValue = "0") Integer page) {
-		RoomMembersResponse response = roomMemberService.getRoomMembers(currentUser.getUserId(), roomId, sortType, page);
+		RoomMembersResponse response = roomMemberService.getRoomMembers(currentUserId, roomId, sortType, page);
 		return ResponseEntity.ok(BaseResponse.of(response));
 	}
 

--- a/src/main/java/io/driver/codrive/modules/room/domain/Room.java
+++ b/src/main/java/io/driver/codrive/modules/room/domain/Room.java
@@ -157,9 +157,4 @@ public class Room extends BaseEntity {
 	public void deleteLanguages(List<RoomLanguageMapping> mappings) {
 		roomLanguageMappings.removeAll(mappings);
 	}
-
-	@Override
-	public Long getOwnerId() {
-		return this.owner.getUserId();
-	}
 }

--- a/src/main/java/io/driver/codrive/modules/room/domain/RoomRepository.java
+++ b/src/main/java/io/driver/codrive/modules/room/domain/RoomRepository.java
@@ -5,12 +5,17 @@ import java.util.Optional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import io.driver.codrive.modules.user.domain.User;
 
 @Repository
 public interface RoomRepository extends JpaRepository<Room, Long>, RoomRepositoryCustom {
+	@Query("SELECT r.owner.userId FROM Room r WHERE r.roomId = :roomId")
+	Long findOwnerIdByRoomId(@Param("roomId") Long roomId);
+
 	Page<Room> findAll(Pageable pageable);
 	Optional<Room> findByUuid(String uuid);
 	Page<Room> findByTitleContaining(String keyword, Pageable pageable);

--- a/src/main/java/io/driver/codrive/modules/room/service/RoomMemberService.java
+++ b/src/main/java/io/driver/codrive/modules/room/service/RoomMemberService.java
@@ -34,10 +34,10 @@ public class RoomMemberService {
 	private final RoomRequestService roomRequestService;
 	private final RoomUserMappingService roomUserMappingService;
 
-	@Transactional
-	public RoomMembersResponse getRoomMembers(Long roomId, SortType sortType, int page) {
+	@Transactional(readOnly = true)
+	public RoomMembersResponse getRoomMembers(Long userId, Long roomId, SortType sortType, int page) {
 		Room room = roomService.getRoomById(roomId);
-		User user = userService.getUserById(AuthUtils.getCurrentUserId());
+		User user = userService.getUserById(userId);
 		if (!room.hasMember(user)) {
 			throw new IllegalArgumentApplicationException("활동 중인 그룹의 정보만 조회할 수 있습니다.");
 		}

--- a/src/main/java/io/driver/codrive/modules/room/service/RoomMemberService.java
+++ b/src/main/java/io/driver/codrive/modules/room/service/RoomMemberService.java
@@ -4,11 +4,11 @@ package io.driver.codrive.modules.room.service;
 import java.util.List;
 
 import org.springframework.data.domain.*;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import io.driver.codrive.global.exception.IllegalArgumentApplicationException;
-import io.driver.codrive.global.util.AuthUtils;
 import io.driver.codrive.global.util.PageUtils;
 import io.driver.codrive.modules.mappings.roomUserMapping.service.RoomUserMappingService;
 import io.driver.codrive.modules.room.domain.Room;
@@ -49,9 +49,9 @@ public class RoomMemberService {
 	}
 
 	@Transactional
+	@PreAuthorize("@roomAccessHandler.isOwner(#roomId)")
 	public RoomParticipantListResponse getRoomParticipants(Long roomId, SortType sortType, int page) {
 		Room room = roomService.getRoomById(roomId);
-		AuthUtils.checkOwnedEntity(room);
 		if (room.isFull()) {
 			roomRequestService.changeWaitingRoomRequestStatus(room, UserRequestStatus.REQUESTED, UserRequestStatus.WAITING);
 		} else {
@@ -69,9 +69,9 @@ public class RoomMemberService {
 	}
 
 	@Transactional
+	@PreAuthorize("@roomAccessHandler.isOwner(#roomId)")
 	public void kickMember(Long roomId, Long userId) {
 		Room room = roomService.getRoomById(roomId);
-		AuthUtils.checkOwnedEntity(room);
 		User user = userService.getUserById(userId);
 		roomUserMappingService.deleteRoomUserMapping(room, user);
 		roomRequestService.deleteRoomRequest(room, user);

--- a/src/main/java/io/driver/codrive/modules/room/service/RoomService.java
+++ b/src/main/java/io/driver/codrive/modules/room/service/RoomService.java
@@ -59,8 +59,8 @@ public class RoomService {
 	private final RoomRequestService roomRequestService;
 
 	@Transactional
-	public RoomCreateResponse createRoom(RoomCreateRequest request, MultipartFile imageFile) throws IOException {
-		User user = userService.getUserById(AuthUtils.getCurrentUserId());
+	public RoomCreateResponse createRoom(Long userId, RoomCreateRequest request, MultipartFile imageFile) throws IOException {
+		User user = userService.getUserById(userId);
 		String imageSrc = BASE_ROOM_IMAGE_URL;
 		if (imageFile != null) {
 			imageSrc = imageService.uploadImage(imageFile);
@@ -72,23 +72,21 @@ public class RoomService {
 		return RoomCreateResponse.of(savedRoom);
 	}
 
-	@Transactional
 	public Room getRoomById(Long roomId) {
 		return roomRepository.findById(roomId).orElseThrow(() -> new NotFoundApplicationException("그룹"));
 	}
 
-	@Transactional
-	public RoomDetailResponse getRoomDetail(Long roomId) {
+	@Transactional(readOnly = true)
+	public RoomDetailResponse getRoomDetail(User user, Long roomId) {
 		Room room = getRoomById(roomId);
-		User user = userService.getUserById(AuthUtils.getCurrentUserId());
-		int requestedCount = roomRequestService.getRoomsRequestByRoom(room).size();
+		int requestedCount = roomRequestService.getRoomRequestByRoom(room).size();
 		return RoomDetailResponse.of(room, requestedCount, room.hasMember(user));
 	}
 
-	@Transactional
-	public JoinedRoomInfoResponse getJoinedRoomInfo(Long roomId) {
+	@Transactional(readOnly = true)
+	public JoinedRoomInfoResponse getJoinedRoomInfo(Long userId, Long roomId) {
+		User user = userService.getUserById(userId);
 		Room room = getRoomById(roomId);
-		User user = userService.getUserById(AuthUtils.getCurrentUserId());
 		if (!room.hasMember(user)) {
 			throw new IllegalArgumentApplicationException("활동 중인 그룹의 정보만 조회할 수 있습니다.");
 		}
@@ -96,16 +94,12 @@ public class RoomService {
 		if (room.getOwner().equals(user)) {
 			password = room.getPassword();
 		}
-		int approvedCount = roomRequestService.getRoomRequestCountByRoomAndRequestStatus(room,
-			UserRequestStatus.JOINED);
-		int requestedCount =
-			roomRequestService.getRoomRequestCountByRoomAndRequestStatus(room, UserRequestStatus.REQUESTED) +
-				roomRequestService.getRoomRequestCountByRoomAndRequestStatus(room, UserRequestStatus.WAITING);
+		int approvedCount = roomRequestService.getRoomRequestCountByRoomAndRequestStatus(room, UserRequestStatus.JOINED);
+		int requestedCount = roomRequestService.getRoomRequestByRoom(room).size() - approvedCount;
 		return JoinedRoomInfoResponse.of(room, password, approvedCount, requestedCount,
 			roomUserMappingService.getLanguageMemberCountResponse(room));
 	}
 
-	@Transactional
 	public RoomUuidResponse getRoomInfoByUuid(String uuid) {
 		Room room = roomRepository.findByUuid(uuid).orElseThrow(() -> new NotFoundApplicationException("그룹"));
 		return RoomUuidResponse.of(room);
@@ -157,17 +151,16 @@ public class RoomService {
 		}
 	}
 
-	@Transactional
+	@Transactional(readOnly = true)
 	public JoinedRoomTitleResponse getJoinedRoomTitle(Long userId) {
 		User user = userService.getUserById(userId);
 		List<Room> rooms = user.getJoinedRooms();
 		return JoinedRoomTitleResponse.of(rooms);
 	}
 
-	@Transactional
-	public JoinedRoomListResponse getJoinedRoomList(Long userId, SortType sortType, Integer page, String status) {
+	@Transactional(readOnly = true)
+	public JoinedRoomListResponse getJoinedRoomList(Long userId, User currentUser, SortType sortType, Integer page, String status) {
 		User user = userService.getUserById(userId);
-		User currentUser = userService.getUserById(AuthUtils.getCurrentUserId());
 		RoomStatus roomStatus = getRoomStatus(status);
 		if (page != null) {
 			Pageable pageable = PageRequest.of(page, ROOMS_SIZE);
@@ -214,30 +207,29 @@ public class RoomService {
 		}
 	}
 
-	@Transactional
+	@Transactional(readOnly = true)
 	public RoomRecommendResponse getRecommendRoomRandomList(Long userId) {
 		User user = userService.getUserById(userId);
-		AuthUtils.checkOwnedEntity(user);
 		List<Room> rooms = roomRepository.getRoomsByLanguageExcludingJoinedRoom(user.getLanguage().getLanguageId(),
 			user.getUserId());
 		return RoomRecommendResponse.of(rooms);
 	}
 
 	@Transactional(readOnly = true)
-	public RoomListResponse searchRooms(String keyword, int page) {
+	public RoomListResponse searchRooms(Long userId, String keyword, int page) {
 		PageUtils.validatePageable(page, ROOMS_SIZE);
 		Pageable pageable = PageRequest.of(page, ROOMS_SIZE);
 		Page<Room> rooms = roomRepository.findByTitleContaining(keyword, pageable);
-		User user = userService.getUserById(AuthUtils.getCurrentUserId());
+		User user = userService.getUserById(userId);
 		return RoomListResponse.of(rooms.getTotalPages(), rooms.getContent(), user);
 	}
 
 	@Transactional(readOnly = true)
-	public RoomListResponse filterRooms(SortType sortType, RoomFilterRequest request, int page) {
+	public RoomListResponse filterRooms(Long userId, SortType sortType, RoomFilterRequest request, int page) {
 		Pageable pageable = PageRequest.of(page, ROOMS_SIZE);
 		RoomFilterDto roomFilterDto = getRoomFilterDto(request);
 		Page<Room> rooms = roomRepository.filterRooms(roomFilterDto, pageable, sortType);
-		User user = userService.getUserById(AuthUtils.getCurrentUserId());
+		User user = userService.getUserById(userId);
 		return RoomListResponse.of(rooms.getTotalPages(), rooms.getContent(), user);
 	}
 
@@ -254,9 +246,9 @@ public class RoomService {
 		return RoomFilterDto.toRoomFilterDto(request, tagIds);
 	}
 
-	@Transactional
-	public RecentRoomResponse getRecentRooms() {
-		User user = userService.getUserById(AuthUtils.getCurrentUserId());
+	@Transactional(readOnly = true)
+	public RecentRoomResponse getRecentRooms(Long userId) {
+		User user = userService.getUserById(userId);
 		List<Room> rooms = user.getJoinedRooms();
 		if (!rooms.isEmpty()) {
 			rooms = rooms.stream().sorted(getRecentRoomComparator()).collect(Collectors.toList());

--- a/src/main/java/io/driver/codrive/modules/roomRequest/controller/RoomRequestController.java
+++ b/src/main/java/io/driver/codrive/modules/roomRequest/controller/RoomRequestController.java
@@ -47,7 +47,7 @@ public class RoomRequestController {
 	)
 	@PostMapping("/{roomId}/private")
 	public ResponseEntity<BaseResponse<Void>> joinPrivateRoom(@PathVariable(name = "roomId") Long roomId,
-		@Valid @RequestBody PasswordRequest request, @AuthenticatedUserId Long currentUserId) {
+		@Valid @RequestBody PasswordRequest request, @Parameter(hidden = true)  @AuthenticatedUserId Long currentUserId) {
 		roomRequestService.joinPrivateRoom(roomId, request, currentUserId);
 		return ResponseEntity.ok(BaseResponse.of(null));
 	}

--- a/src/main/java/io/driver/codrive/modules/roomRequest/controller/RoomRequestController.java
+++ b/src/main/java/io/driver/codrive/modules/roomRequest/controller/RoomRequestController.java
@@ -3,13 +3,12 @@ package io.driver.codrive.modules.roomRequest.controller;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
-import io.driver.codrive.global.auth.AuthenticatedUser;
+import io.driver.codrive.global.auth.AuthenticatedUserId;
 import io.driver.codrive.global.constants.APIConstants;
 import io.driver.codrive.global.model.BaseResponse;
 import io.driver.codrive.modules.roomRequest.model.request.PasswordRequest;
 import io.driver.codrive.modules.roomRequest.model.response.RoomRequestListResponse;
 import io.driver.codrive.modules.roomRequest.service.RoomRequestService;
-import io.driver.codrive.modules.user.domain.User;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.enums.ParameterIn;
@@ -48,8 +47,8 @@ public class RoomRequestController {
 	)
 	@PostMapping("/{roomId}/private")
 	public ResponseEntity<BaseResponse<Void>> joinPrivateRoom(@PathVariable(name = "roomId") Long roomId,
-		@Valid @RequestBody PasswordRequest request, @AuthenticatedUser User currentUser) {
-		roomRequestService.joinPrivateRoom(roomId, request, currentUser.getUserId());
+		@Valid @RequestBody PasswordRequest request, @AuthenticatedUserId Long currentUserId) {
+		roomRequestService.joinPrivateRoom(roomId, request, currentUserId);
 		return ResponseEntity.ok(BaseResponse.of(null));
 	}
 
@@ -68,8 +67,8 @@ public class RoomRequestController {
 	)
 	@PostMapping("/{roomId}/public")
 	public ResponseEntity<BaseResponse<Void>> joinPublicRoom(@PathVariable(name = "roomId") Long roomId,
-		@AuthenticatedUser User currentUser) {
-		roomRequestService.joinPublicRoom(roomId, currentUser.getUserId());
+		@AuthenticatedUserId Long currentUserId) {
+		roomRequestService.joinPublicRoom(roomId, currentUserId);
 		return ResponseEntity.ok(BaseResponse.of(null));
 	}
 

--- a/src/main/java/io/driver/codrive/modules/roomRequest/controller/RoomRequestController.java
+++ b/src/main/java/io/driver/codrive/modules/roomRequest/controller/RoomRequestController.java
@@ -3,11 +3,13 @@ package io.driver.codrive.modules.roomRequest.controller;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import io.driver.codrive.global.auth.AuthenticatedUser;
 import io.driver.codrive.global.constants.APIConstants;
 import io.driver.codrive.global.model.BaseResponse;
 import io.driver.codrive.modules.roomRequest.model.request.PasswordRequest;
 import io.driver.codrive.modules.roomRequest.model.response.RoomRequestListResponse;
 import io.driver.codrive.modules.roomRequest.service.RoomRequestService;
+import io.driver.codrive.modules.user.domain.User;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.enums.ParameterIn;
@@ -46,8 +48,8 @@ public class RoomRequestController {
 	)
 	@PostMapping("/{roomId}/private")
 	public ResponseEntity<BaseResponse<Void>> joinPrivateRoom(@PathVariable(name = "roomId") Long roomId,
-		@Valid @RequestBody PasswordRequest request) {
-		roomRequestService.joinPrivateRoom(roomId, request);
+		@Valid @RequestBody PasswordRequest request, @AuthenticatedUser User currentUser) {
+		roomRequestService.joinPrivateRoom(roomId, request, currentUser.getUserId());
 		return ResponseEntity.ok(BaseResponse.of(null));
 	}
 
@@ -65,8 +67,9 @@ public class RoomRequestController {
 		}
 	)
 	@PostMapping("/{roomId}/public")
-	public ResponseEntity<BaseResponse<Void>> joinPublicRoom(@PathVariable(name = "roomId") Long roomId) {
-		roomRequestService.joinPublicRoom(roomId);
+	public ResponseEntity<BaseResponse<Void>> joinPublicRoom(@PathVariable(name = "roomId") Long roomId,
+		@AuthenticatedUser User currentUser) {
+		roomRequestService.joinPublicRoom(roomId, currentUser.getUserId());
 		return ResponseEntity.ok(BaseResponse.of(null));
 	}
 

--- a/src/main/java/io/driver/codrive/modules/roomRequest/domain/RoomRequest.java
+++ b/src/main/java/io/driver/codrive/modules/roomRequest/domain/RoomRequest.java
@@ -54,9 +54,4 @@ public class RoomRequest extends BaseEntity {
 	public void changeRoomRequestStatus(UserRequestStatus userRequestStatus) {
 		this.userRequestStatus = userRequestStatus;
 	}
-
-	@Override
-	public Long getOwnerId() {
-		return this.room.getOwnerId();
-	}
 }

--- a/src/main/java/io/driver/codrive/modules/roomRequest/service/RoomRequestService.java
+++ b/src/main/java/io/driver/codrive/modules/roomRequest/service/RoomRequestService.java
@@ -4,12 +4,12 @@ import java.util.List;
 
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import io.driver.codrive.global.exception.IllegalArgumentApplicationException;
 import io.driver.codrive.global.exception.NotFoundApplicationException;
-import io.driver.codrive.global.util.AuthUtils;
 import io.driver.codrive.global.util.MessageUtils;
 import io.driver.codrive.modules.mappings.roomUserMapping.service.RoomUserMappingService;
 import io.driver.codrive.modules.notification.domain.NotificationType;
@@ -122,9 +122,9 @@ public class RoomRequestService {
 	}
 
 	@Transactional
+	@PreAuthorize("@roomAccessHandler.isOwner(#roomId)")
 	public void approveRequest(Long roomId, Long roomRequestId) {
 		Room room = getRoomById(roomId);
-		AuthUtils.checkOwnedEntity(room);
 		RoomRequest roomRequest = getRoomRequestById(roomRequestId);
 
 		if (!roomRequest.compareStatus(UserRequestStatus.REQUESTED)) {

--- a/src/main/java/io/driver/codrive/modules/roomRequest/service/RoomRequestService.java
+++ b/src/main/java/io/driver/codrive/modules/roomRequest/service/RoomRequestService.java
@@ -36,8 +36,8 @@ public class RoomRequestService {
 	private final RoomRequestRepository roomRequestRepository;
 
 	@Transactional
-	public void joinPrivateRoom(Long roomId, PasswordRequest request) {
-		User user = userService.getUserById(AuthUtils.getCurrentUserId());
+	public void joinPrivateRoom(Long roomId, PasswordRequest request, Long userId) {
+		User user = userService.getUserById(userId);
 		Room room = getRoomById(roomId);
 		checkRoomStatus(room);
 		checkRoomMember(room, user);
@@ -63,8 +63,8 @@ public class RoomRequestService {
 	}
 
 	@Transactional
-	public void joinPublicRoom(Long roomId) {
-		User user = userService.getUserById(AuthUtils.getCurrentUserId());
+	public void joinPublicRoom(Long roomId, Long userId) {
+		User user = userService.getUserById(userId);
 		Room room = getRoomById(roomId);
 		checkRoomStatus(room);
 		checkRoomMember(room, user);
@@ -101,23 +101,20 @@ public class RoomRequestService {
 		}
 	}
 
-	@Transactional
 	protected void saveRoomRequest(RoomRequest roomRequest, Room room) {
 		roomRequestRepository.save(roomRequest);
 		room.addRoomRequests(roomRequest);
 	}
 
-	@Transactional
 	public RoomRequest getRoomRequestById(Long roomRequestId) {
 		return roomRequestRepository.findById(roomRequestId)
 			.orElseThrow(() -> new NotFoundApplicationException("참여 요청 데이터"));
 	}
 
-	@Transactional
 	public RoomRequestListResponse getRoomRequests(Long roomId) {
 		Room room = getRoomById(roomId);
 		int approvedCount = getRoomRequestCountByRoomAndRequestStatus(room, UserRequestStatus.JOINED);
-		return RoomRequestListResponse.of(approvedCount, getRoomsRequestByRoom(room));
+		return RoomRequestListResponse.of(approvedCount, getRoomRequestByRoom(room));
 	}
 
 	public Page<RoomRequest> getRoomParticipants(Room room, Pageable pageable) {
@@ -156,19 +153,16 @@ public class RoomRequestService {
 		roomRequestRepository.delete(roomRequest);
 	}
 
-	@Transactional(readOnly = true)
 	public Room getRoomById(Long roomId) {
 		return roomRepository.findById(roomId)
 			.orElseThrow(() -> new NotFoundApplicationException("그룹"));
 	}
 
-	@Transactional(readOnly = true)
 	public int getRoomRequestCountByRoomAndRequestStatus(Room room, UserRequestStatus userRequestStatus) {
 		return roomRequestRepository.findAllByRoomAndUserRequestStatus(room, userRequestStatus).size();
 	}
 
-	@Transactional(readOnly = true)
-	public List<RoomRequest> getRoomsRequestByRoom(Room room) {
+	public List<RoomRequest> getRoomRequestByRoom(Room room) {
 		return roomRequestRepository.findAllByRoom(room);
 	}
 }

--- a/src/main/java/io/driver/codrive/modules/test/TestController.java
+++ b/src/main/java/io/driver/codrive/modules/test/TestController.java
@@ -4,7 +4,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import io.driver.codrive.global.constants.APIConstants;
-import io.driver.codrive.global.jwt.JwtProvider;
+import io.driver.codrive.global.auth.JwtProvider;
 import io.driver.codrive.global.model.BaseResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;

--- a/src/main/java/io/driver/codrive/modules/user/controller/UserController.java
+++ b/src/main/java/io/driver/codrive/modules/user/controller/UserController.java
@@ -3,8 +3,10 @@ package io.driver.codrive.modules.user.controller;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import io.driver.codrive.global.auth.AuthenticatedUser;
 import io.driver.codrive.global.constants.APIConstants;
 import io.driver.codrive.global.model.BaseResponse;
+import io.driver.codrive.modules.user.domain.User;
 import io.driver.codrive.modules.user.model.request.GithubRepositoryNameRequest;
 import io.driver.codrive.modules.user.model.response.*;
 import io.driver.codrive.modules.user.model.request.GoalChangeRequest;
@@ -22,11 +24,14 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
 @Tag(name = "User API", description = "사용자 관련 API")
 @RestController
 @RequestMapping(APIConstants.API_PREFIX + "/users")
 @RequiredArgsConstructor
+@Slf4j
+
 public class UserController {
 	private final UserService userService;
 	private final UserAchievementService userAchievementService;
@@ -82,8 +87,8 @@ public class UserController {
 		}
 	)
 	@PostMapping("/repository")
-	public ResponseEntity<BaseResponse<Void>> checkGithubRepositoryName(@RequestBody GithubRepositoryNameRequest request) {
-		userService.checkGithubRepositoryName(request);
+	public ResponseEntity<BaseResponse<Void>> checkGithubRepositoryName(@AuthenticatedUser User currentUser, @RequestBody GithubRepositoryNameRequest request) {
+		userService.checkGithubRepositoryName(currentUser.getUserId(), request);
 		return ResponseEntity.ok(BaseResponse.of(null));
 	}
 
@@ -160,8 +165,8 @@ public class UserController {
 		}
 	)
 	@GetMapping("/followings")
-	public ResponseEntity<BaseResponse<FollowListResponse>> getFollowings() {
-		FollowListResponse response = userService.getFollowings();
+	public ResponseEntity<BaseResponse<FollowListResponse>> getFollowings(@AuthenticatedUser User currentUser) {
+		FollowListResponse response = userService.getFollowings(currentUser.getUserId());
 		return ResponseEntity.ok(BaseResponse.of(response));
 	}
 
@@ -172,8 +177,8 @@ public class UserController {
 		}
 	)
 	@GetMapping("/followers")
-	public ResponseEntity<BaseResponse<FollowListResponse>> getFollowers() {
-		FollowListResponse response = userService.getFollowers();
+	public ResponseEntity<BaseResponse<FollowListResponse>> getFollowers(@AuthenticatedUser User currentUser) {
+		FollowListResponse response = userService.getFollowers(currentUser.getUserId());
 		return ResponseEntity.ok(BaseResponse.of(response));
 	}
 
@@ -185,8 +190,8 @@ public class UserController {
 		}
 	)
 	@GetMapping("/achieve")
-	public ResponseEntity<BaseResponse<UserAchievementResponse>> getAchievement() {
-		UserAchievementResponse response = userAchievementService.getAchievement();
+	public ResponseEntity<BaseResponse<UserAchievementResponse>> getAchievement(@AuthenticatedUser User currentUser) {
+		UserAchievementResponse response = userAchievementService.getAchievement(currentUser.getUserId());
 		return ResponseEntity.ok(BaseResponse.of(response));
 	}
 
@@ -201,8 +206,9 @@ public class UserController {
 		}
 	)
 	@GetMapping("/{userId}/profile")
-	public ResponseEntity<BaseResponse<UserProfileResponse>> getProfile(@PathVariable(name = "userId") Long userId) {
-		UserProfileResponse response = userService.getProfile(userId);
+	public ResponseEntity<BaseResponse<UserProfileResponse>> getProfile(@AuthenticatedUser User currentUser,
+		@PathVariable(name = "userId") Long userId) {
+		UserProfileResponse response = userService.getProfile(currentUser.getUserId(), userId);
 		return ResponseEntity.ok(BaseResponse.of(response));
 	}
 

--- a/src/main/java/io/driver/codrive/modules/user/controller/UserController.java
+++ b/src/main/java/io/driver/codrive/modules/user/controller/UserController.java
@@ -3,10 +3,9 @@ package io.driver.codrive.modules.user.controller;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
-import io.driver.codrive.global.auth.AuthenticatedUser;
+import io.driver.codrive.global.auth.AuthenticatedUserId;
 import io.driver.codrive.global.constants.APIConstants;
 import io.driver.codrive.global.model.BaseResponse;
-import io.driver.codrive.modules.user.domain.User;
 import io.driver.codrive.modules.user.model.request.GithubRepositoryNameRequest;
 import io.driver.codrive.modules.user.model.response.*;
 import io.driver.codrive.modules.user.model.request.GoalChangeRequest;
@@ -31,7 +30,6 @@ import lombok.extern.slf4j.Slf4j;
 @RequestMapping(APIConstants.API_PREFIX + "/users")
 @RequiredArgsConstructor
 @Slf4j
-
 public class UserController {
 	private final UserService userService;
 	private final UserAchievementService userAchievementService;
@@ -87,8 +85,8 @@ public class UserController {
 		}
 	)
 	@PostMapping("/repository")
-	public ResponseEntity<BaseResponse<Void>> checkGithubRepositoryName(@AuthenticatedUser User currentUser, @RequestBody GithubRepositoryNameRequest request) {
-		userService.checkGithubRepositoryName(currentUser.getUserId(), request);
+	public ResponseEntity<BaseResponse<Void>> checkGithubRepositoryName(@AuthenticatedUserId Long currentUserId, @RequestBody GithubRepositoryNameRequest request) {
+		userService.checkGithubRepositoryName(currentUserId, request);
 		return ResponseEntity.ok(BaseResponse.of(null));
 	}
 
@@ -165,8 +163,8 @@ public class UserController {
 		}
 	)
 	@GetMapping("/followings")
-	public ResponseEntity<BaseResponse<FollowListResponse>> getFollowings(@AuthenticatedUser User currentUser) {
-		FollowListResponse response = userService.getFollowings(currentUser.getUserId());
+	public ResponseEntity<BaseResponse<FollowListResponse>> getFollowings(@AuthenticatedUserId Long currentUserId) {
+		FollowListResponse response = userService.getFollowings(currentUserId);
 		return ResponseEntity.ok(BaseResponse.of(response));
 	}
 
@@ -177,8 +175,8 @@ public class UserController {
 		}
 	)
 	@GetMapping("/followers")
-	public ResponseEntity<BaseResponse<FollowListResponse>> getFollowers(@AuthenticatedUser User currentUser) {
-		FollowListResponse response = userService.getFollowers(currentUser.getUserId());
+	public ResponseEntity<BaseResponse<FollowListResponse>> getFollowers(@AuthenticatedUserId Long currentUserId) {
+		FollowListResponse response = userService.getFollowers(currentUserId);
 		return ResponseEntity.ok(BaseResponse.of(response));
 	}
 
@@ -190,8 +188,8 @@ public class UserController {
 		}
 	)
 	@GetMapping("/achieve")
-	public ResponseEntity<BaseResponse<UserAchievementResponse>> getAchievement(@AuthenticatedUser User currentUser) {
-		UserAchievementResponse response = userAchievementService.getAchievement(currentUser.getUserId());
+	public ResponseEntity<BaseResponse<UserAchievementResponse>> getAchievement(@AuthenticatedUserId Long currentUserId) {
+		UserAchievementResponse response = userAchievementService.getAchievement(currentUserId);
 		return ResponseEntity.ok(BaseResponse.of(response));
 	}
 
@@ -206,9 +204,9 @@ public class UserController {
 		}
 	)
 	@GetMapping("/{userId}/profile")
-	public ResponseEntity<BaseResponse<UserProfileResponse>> getProfile(@AuthenticatedUser User currentUser,
+	public ResponseEntity<BaseResponse<UserProfileResponse>> getProfile(@AuthenticatedUserId Long currentUserId,
 		@PathVariable(name = "userId") Long userId) {
-		UserProfileResponse response = userService.getProfile(currentUser.getUserId(), userId);
+		UserProfileResponse response = userService.getProfile(currentUserId, userId);
 		return ResponseEntity.ok(BaseResponse.of(response));
 	}
 

--- a/src/main/java/io/driver/codrive/modules/user/controller/UserController.java
+++ b/src/main/java/io/driver/codrive/modules/user/controller/UserController.java
@@ -85,7 +85,9 @@ public class UserController {
 		}
 	)
 	@PostMapping("/repository")
-	public ResponseEntity<BaseResponse<Void>> checkGithubRepositoryName(@AuthenticatedUserId Long currentUserId, @RequestBody GithubRepositoryNameRequest request) {
+	public ResponseEntity<BaseResponse<Void>> checkGithubRepositoryName(
+		@Parameter(hidden = true) @AuthenticatedUserId Long currentUserId,
+		@RequestBody GithubRepositoryNameRequest request) {
 		userService.checkGithubRepositoryName(currentUserId, request);
 		return ResponseEntity.ok(BaseResponse.of(null));
 	}
@@ -163,7 +165,8 @@ public class UserController {
 		}
 	)
 	@GetMapping("/followings")
-	public ResponseEntity<BaseResponse<FollowListResponse>> getFollowings(@AuthenticatedUserId Long currentUserId) {
+	public ResponseEntity<BaseResponse<FollowListResponse>> getFollowings(
+		@Parameter(hidden = true) @AuthenticatedUserId Long currentUserId) {
 		FollowListResponse response = userService.getFollowings(currentUserId);
 		return ResponseEntity.ok(BaseResponse.of(response));
 	}
@@ -175,7 +178,8 @@ public class UserController {
 		}
 	)
 	@GetMapping("/followers")
-	public ResponseEntity<BaseResponse<FollowListResponse>> getFollowers(@AuthenticatedUserId Long currentUserId) {
+	public ResponseEntity<BaseResponse<FollowListResponse>> getFollowers(
+		@Parameter(hidden = true) @AuthenticatedUserId Long currentUserId) {
 		FollowListResponse response = userService.getFollowers(currentUserId);
 		return ResponseEntity.ok(BaseResponse.of(response));
 	}
@@ -188,7 +192,8 @@ public class UserController {
 		}
 	)
 	@GetMapping("/achieve")
-	public ResponseEntity<BaseResponse<UserAchievementResponse>> getAchievement(@AuthenticatedUserId Long currentUserId) {
+	public ResponseEntity<BaseResponse<UserAchievementResponse>> getAchievement(
+		@Parameter(hidden = true) @AuthenticatedUserId Long currentUserId) {
 		UserAchievementResponse response = userAchievementService.getAchievement(currentUserId);
 		return ResponseEntity.ok(BaseResponse.of(response));
 	}
@@ -204,7 +209,8 @@ public class UserController {
 		}
 	)
 	@GetMapping("/{userId}/profile")
-	public ResponseEntity<BaseResponse<UserProfileResponse>> getProfile(@AuthenticatedUserId Long currentUserId,
+	public ResponseEntity<BaseResponse<UserProfileResponse>> getProfile(
+		@Parameter(hidden = true) @AuthenticatedUserId Long currentUserId,
 		@PathVariable(name = "userId") Long userId) {
 		UserProfileResponse response = userService.getProfile(currentUserId, userId);
 		return ResponseEntity.ok(BaseResponse.of(response));

--- a/src/main/java/io/driver/codrive/modules/user/domain/User.java
+++ b/src/main/java/io/driver/codrive/modules/user/domain/User.java
@@ -179,9 +179,4 @@ public class User extends BaseEntity {
 		}
 		return this.followings.stream().anyMatch(follow -> follow.getFollowing().equals(target));
 	}
-
-	@Override
-	public Long getOwnerId() {
-		return this.userId;
-	}
 }

--- a/src/main/java/io/driver/codrive/modules/user/service/UserAchievementService.java
+++ b/src/main/java/io/driver/codrive/modules/user/service/UserAchievementService.java
@@ -5,7 +5,6 @@ import java.time.LocalDate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import io.driver.codrive.global.util.AuthUtils;
 import io.driver.codrive.modules.record.service.RecordService;
 import io.driver.codrive.modules.user.domain.User;
 import io.driver.codrive.modules.user.model.response.UserAchievementResponse;
@@ -17,20 +16,20 @@ public class UserAchievementService {
 	private final UserService userService;
 	private final RecordService recordService;
 
-	@Transactional
-	public UserAchievementResponse getAchievement() {
-		User user = userService.getUserById(AuthUtils.getCurrentUserId());
+	@Transactional(readOnly = true)
+	public UserAchievementResponse getAchievement(Long userId) {
+		User user = userService.getUserById(userId);
 		int goal = user.getGoal();
 		int todayCount = recordService.getTodayRecordCount(user);
 		int successRate = user.getSuccessRate();
-		int weeklyCount = recordService.getRecordsCountByWeek(user, LocalDate.now());
-		int weeklyCountDifference = weeklyCount - getLastWeeklyCount(user);
+		int weeklyCount = recordService.getRecordsCountByWeek(user.getUserId(), LocalDate.now());
+		int weeklyCountDifference = weeklyCount - getLastWeeklyCount(user.getUserId());
 		return UserAchievementResponse.of(goal, todayCount, successRate, weeklyCount, weeklyCountDifference);
 	}
 
 	@Transactional
-	protected int getLastWeeklyCount(User user) {
+	protected int getLastWeeklyCount(Long userId) {
 		LocalDate lastWeekDate = LocalDate.now().minusWeeks(1);
-		return recordService.getRecordsCountByWeek(user, lastWeekDate);
+		return recordService.getRecordsCountByWeek(userId, lastWeekDate);
 	}
 }

--- a/src/main/java/io/driver/codrive/modules/user/service/UserService.java
+++ b/src/main/java/io/driver/codrive/modules/user/service/UserService.java
@@ -50,9 +50,9 @@ public class UserService {
 	}
 
 	@Transactional(readOnly = true)
-	public UserProfileResponse getProfile(Long userId) {
+	public UserProfileResponse getProfile(Long currentUserId, Long userId) {
+		User currentUser = getUserById(currentUserId);
 		User user = getUserById(userId);
-		User currentUser = getUserById(AuthUtils.getCurrentUserId());
 		Boolean isFollowing = currentUser.isFollowing(user);
 		return UserProfileResponse.of(user, isFollowing);
 	}
@@ -63,11 +63,10 @@ public class UserService {
 		}
 	}
 
-	public void checkGithubRepositoryName(GithubRepositoryNameRequest request) {
-		User user = getUserById(AuthUtils.getCurrentUserId());
-		boolean isExistRepository = githubCommitService.isExistRepository(user, request.githubRepositoryName());
+	public void checkGithubRepositoryName(Long userId, GithubRepositoryNameRequest request) {
+		boolean isExistRepository = githubCommitService.isExistRepository(userId, request.githubRepositoryName());
 		if (!isExistRepository) {
-			throw new NotFoundApplicationException("레포지토리");
+			throw new NotFoundApplicationException("리포지토리");
 		}
 	}
 
@@ -103,22 +102,21 @@ public class UserService {
 	}
 
 	@Transactional(readOnly = true)
-	public FollowListResponse getFollowings() {
-		User user = getUserById(AuthUtils.getCurrentUserId());
+	public FollowListResponse getFollowings(Long userId) {
+		User user = getUserById(userId);
 		List<User> followings = user.getFollowings().stream().map(Follow::getFollowing).toList();
 		return FollowListResponse.ofFollowings(followings);
 	}
 
 	@Transactional(readOnly = true)
-	public FollowListResponse getFollowers() {
-		User user = getUserById(AuthUtils.getCurrentUserId());
+	public FollowListResponse getFollowers(Long userId) {
+		User user = getUserById(userId);
 		List<User> followers = user.getFollowers().stream().map(Follow::getFollower).toList();
 		return FollowListResponse.ofFollowers(followers, user);
 	}
 
-	@Transactional(readOnly = true)
-	public List<User> getRandomUsersExcludingMeAndFollowings(User user){
-		return userRepository.getRandomUsersExcludingMeAndFollowings(user.getUserId());
+ 	public List<User> getRandomUsersExcludingMeAndFollowings(Long userId){
+		return userRepository.getRandomUsersExcludingMeAndFollowings(userId);
 	}
 
 	@Scheduled(cron = "0 0 0 * * MON") //매주 월요일 00:00:00에 실행

--- a/src/test/java/io/driver/codrive/modules/record/service/RecordServiceTest.java
+++ b/src/test/java/io/driver/codrive/modules/record/service/RecordServiceTest.java
@@ -1,317 +1,317 @@
-package io.driver.codrive.modules.record.service;
-
-import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.Mockito.*;
-
-import java.io.IOException;
-import java.time.LocalDate;
-import java.time.LocalDateTime;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Optional;
-
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
-import org.mockito.Mock;
-import org.mockito.MockedStatic;
-import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.data.domain.PageImpl;
-import org.springframework.data.domain.PageRequest;
-import org.springframework.security.core.Authentication;
-import org.springframework.security.core.context.SecurityContext;
-import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.test.util.ReflectionTestUtils;
-
-import io.driver.codrive.global.exception.IllegalArgumentApplicationException;
-import io.driver.codrive.global.exception.NotFoundApplicationException;
-import io.driver.codrive.global.util.DateUtils;
-import io.driver.codrive.modules.codeblock.service.CodeblockService;
-import io.driver.codrive.modules.language.domain.Language;
-import io.driver.codrive.modules.record.domain.Platform;
-import io.driver.codrive.modules.record.domain.Record;
-import io.driver.codrive.modules.record.domain.RecordRepository;
-import io.driver.codrive.modules.record.domain.RecordStatus;
-import io.driver.codrive.modules.record.model.request.RecordModifyRequest;
-import io.driver.codrive.modules.record.model.response.RecordDetailResponse;
-import io.driver.codrive.modules.record.model.response.RecordModifyResponse;
-import io.driver.codrive.modules.record.model.response.RecordRecentListResponse;
-import io.driver.codrive.modules.record.model.response.TempRecordListResponse;
-import io.driver.codrive.modules.record.service.github.GithubCommitService;
-import io.driver.codrive.modules.user.domain.User;
-import io.driver.codrive.modules.user.service.UserService;
-
-@ExtendWith(MockitoExtension.class)
-class RecordServiceTest {
-	@InjectMocks
-	private RecordService recordService;
-
-	@Mock
-	private RecordRepository recordRepository;
-
-	@Mock
-	private UserService userService;
-
-	@Mock
-	private GithubCommitService githubCommitService;
-
-	@Mock
-	private CodeblockService codeblockService;
-
-	private Record mockRecord;
-
-	private MockedStatic<SecurityContextHolder> mockedSecurityContextHolder;
-
-	private final User mockUser = User.builder()
-		.userId(1L)
-		.language(Language.builder()
-			.languageId(2L)
-			.name("Java")
-			.build())
-		.build();
-
-	@BeforeEach
-	void setRecord() {
-		mockRecord = Record.builder()
-			.recordId(1L)
-			.title("title")
-			.level(1)
-			.platform(Platform.BAEKJOON)
-			.problemUrl("https://www.acmicpc.net/problem/1000")
-			.recordStatus(RecordStatus.SAVED)
-			.user(mockUser)
-			.codeblocks(new ArrayList<>())
-			.recordCategoryMappings(new ArrayList<>())
-			.build();
-		ReflectionTestUtils.setField(mockRecord, "createdAt", LocalDateTime.now());
-	}
-
-	void setSecurityContext() {
-		SecurityContext securityContext = mock(SecurityContext.class);
-		Authentication authentication = mock(Authentication.class);
-
-		mockedSecurityContextHolder = mockStatic(SecurityContextHolder.class);
-		mockedSecurityContextHolder.when(SecurityContextHolder::getContext).thenReturn(securityContext);
-		when(securityContext.getAuthentication()).thenReturn(authentication);
-		when(authentication.getPrincipal()).thenReturn(1L);
-	}
-
-	void tearDown() {
-		mockedSecurityContextHolder.close();
-	}
-
-	@Test
-	@DisplayName("recordId로 문제 풀이 조회 성공")
-	void getRecordById_success() {
-		//given
-		Long recordId = 1L;
-		when(recordRepository.findById(recordId)).thenReturn(Optional.of(mockRecord));
-
-		//when
-		Record record = recordService.getRecordById(recordId);
-
-		//then
-		assertNotNull(record);
-		assertEquals(recordId, record.getRecordId());
-	}
-
-	@Test
-	@DisplayName("recordId로 문제 풀이 조회 실패_문제 풀이가 존재하지 않을 경우")
-	void getRecordById_faile_notFoundException() {
-		//given
-		Long recordId = 1L;
-		when(recordRepository.findById(recordId)).thenReturn(Optional.empty());
-
-		//when & then
-		assertThrows(NotFoundApplicationException.class, () -> recordService.getRecordById(recordId));
-	}
-
-	@Test
-	@DisplayName("recordId로 문제 풀이 상세 조회 성공")
-	void getRecordDetail_success() {
-		//given
-		Long recordId = 1L;
-		when(recordRepository.findById(recordId)).thenReturn(Optional.of(mockRecord));
-
-		//when
-		RecordDetailResponse response = recordService.getRecordDetail(recordId);
-
-		//then
-		assertAll("RecordDetailResponse",
-			() -> assertNotNull(response),
-			() -> assertEquals(mockRecord.getRecordId(), response.recordId()),
-			() -> assertEquals(mockRecord.getTitle(), response.title()),
-			() -> assertEquals(mockRecord.getLevel(), response.level()),
-			() -> assertEquals(mockRecord.getCategories(), response.tags()),
-			() -> assertEquals(mockRecord.getPlatformName(), response.platform()),
-			() -> assertEquals(mockRecord.getProblemUrl(), response.problemUrl()),
-			() -> assertEquals(mockRecord.getCodeblocks().size(), response.codeblocks().size()),
-			() -> assertEquals(DateUtils.formatCreatedAtByYMDHM(mockRecord.getCreatedAt()), response.createdAt())
-		);
-	}
-
-	@Test
-	@DisplayName("페이지별 임시 문제 풀이 조회 성공")
-	void getTempRecordsByPage_success() {
-		// given
-		setSecurityContext();
-		when(userService.getUserById(1L)).thenReturn(mockUser);
-
-		int page = 0;
-		int size = 1;
-		when(recordRepository
-			.findAllByUserAndRecordStatusOrderByCreatedAtDesc(mockUser, RecordStatus.TEMP, PageRequest.of(page, size)))
-			.thenReturn(new PageImpl<>(List.of(mockRecord)));
-
-		// when
-		TempRecordListResponse response = recordService.getTempRecordsByPage(page, size);
-
-		// then
-		assertAll("TempRecordListResponse",
-			() -> assertNotNull(response),
-			() -> assertEquals(1, response.totalPage()),
-			() -> assertEquals(1, response.records().size())
-		);
-
-		tearDown();
-	}
-
-	@Test
-	@DisplayName("페이지별 임시 문제 풀이 조회 실패_페이지 정보가 올바르지 않을 경우")
-	void getTempRecordsByPage_fail_badRequestException() {
-		//given
-		int page = -1;
-		int size = 1;
-
-		//when & then
-		assertThrows(IllegalArgumentApplicationException.class, () -> recordService.getTempRecordsByPage(page, size));
-	}
-
-	@Test
-	@DisplayName("문제 풀이 수정 성공")
-	void modifyRecord_success() throws IOException {
-		// given
-		setSecurityContext();
-		Long recordId = 1L;
-		when(recordRepository.findById(recordId)).thenReturn(Optional.of(mockRecord));
-
-		// when
-		RecordModifyRequest request = new RecordModifyRequest("new_title", 2, new ArrayList<>(),
-			"백준", "https://www.acmicpc.net/problem/1001", new ArrayList<>());
-		RecordModifyResponse response = recordService.modifyRecord(1L, request);
-
-		// then
-		assertAll("RecordModifyResponse",
-			() -> assertNotNull(response),
-			() -> assertEquals(request.title(), response.title()),
-			() -> assertEquals(request.level(), response.level()),
-			() -> assertEquals(request.tags(), response.tags()),
-			() -> assertEquals(request.platform(), response.platform()),
-			() -> assertEquals(request.problemUrl(), response.problemUrl()),
-			() -> assertEquals(request.codeblocks().size(), response.codeblocks().size())
-		);
-
-		tearDown();
-	}
-
-	@Test
-	@DisplayName("문제 풀이 수정 실패_지원하지 않는 플랫폼일 경우")
-	void modifyRecord_fail_badRequestException_platform() {
-		// given
-		setSecurityContext();
-		Long recordId = 1L;
-		when(recordRepository.findById(recordId)).thenReturn(Optional.of(mockRecord));
-
-		// when
-		RecordModifyRequest request = new RecordModifyRequest("new_title", 2, List.of("완전탐색"),
-			"백준그래머스", "https://www.acmicpc.net/problem/1001", new ArrayList<>());
-
-		//when & then
-		assertThrows(IllegalArgumentApplicationException.class, () -> recordService.modifyRecord(1L, request));
-
-		tearDown();
-	}
-
-	@Test
-	@DisplayName("문제 풀이 삭제 성공")
-	void deleteRecord_success() {
-		// given
-		setSecurityContext();
-		Long recordId = 1L;
-		when(recordRepository.findById(recordId)).thenReturn(Optional.of(mockRecord));
-
-		// when
-		recordService.deleteRecord(recordId);
-
-		// then
-		verify(recordRepository).delete(mockRecord);
-
-		tearDown();
-	}
-
-	@Test
-	@DisplayName("사용자 성과율 업데이트 성공")
-	void updateSuccessRate() {
-		// given
-		when(recordRepository.getSolvedDaysByWeek(1L, LocalDate.now())).thenReturn(1);
-		int expectedSuccessRate = 15;
-
-		// when
-		recordService.updateSuccessRate(mockUser);
-
-		// then
-		assertEquals(expectedSuccessRate, mockUser.getSuccessRate());
-	}
-
-	@Test
-	@DisplayName("최근 문제 풀이 목록 조회 성공")
-	void getRecentRecords_success() {
-		// given
-		Long userId = 1L;
-		when(userService.getUserById(userId)).thenReturn(mockUser);
-		when(recordRepository.findAllByUserAndRecordStatusOrderByCreatedAtDesc(mockUser, RecordStatus.SAVED))
-			.thenReturn(List.of(mockRecord));
-
-		// when
-		RecordRecentListResponse response = recordService.getRecentRecords(userId);
-
-		// then
-		assertAll("RecordRecentListResponse",
-			() -> assertNotNull(response),
-			() -> assertEquals(1, response.records().size())
-		);
-	}
-
-	@Test
-	@DisplayName("특정 주에 작성한 문제 풀이 개수 조회")
-	void getRecordsCountByWeek() {
-		// given
-		LocalDate pivotDate = LocalDate.now();
-		when(recordRepository.getRecordsCountByWeek(mockUser.getUserId(), pivotDate)).thenReturn(1);
-
-		// when
-		int count = recordService.getRecordsCountByWeek(mockUser, pivotDate);
-
-		// then
-		assertEquals(1, count);
-	}
-
-	@Test
-	@DisplayName("오늘 작성한 문제 풀이 개수 조회")
-	void getTodayRecordCount() {
-		// given
-		LocalDateTime startOfDay = LocalDate.now().atStartOfDay(); //오늘 00:00:00
-		LocalDateTime endOfDay = LocalDate.now().atTime(23, 59, 59); //오늘 23:59:59
-		when(recordRepository.findAllByUserAndRecordStatusAndCreatedAtBetween(mockUser, RecordStatus.SAVED, startOfDay, endOfDay))
-			.thenReturn(List.of(mockRecord));
-
-		// when
-		int count = recordService.getTodayRecordCount(mockUser);
-
-		// then
-		assertEquals(1, count);
-	}
-
-}
+// package io.driver.codrive.modules.record.service;
+//
+// import static org.junit.jupiter.api.Assertions.*;
+// import static org.mockito.Mockito.*;
+//
+// import java.io.IOException;
+// import java.time.LocalDate;
+// import java.time.LocalDateTime;
+// import java.util.ArrayList;
+// import java.util.List;
+// import java.util.Optional;
+//
+// import org.junit.jupiter.api.BeforeEach;
+// import org.junit.jupiter.api.DisplayName;
+// import org.junit.jupiter.api.Test;
+// import org.junit.jupiter.api.extension.ExtendWith;
+// import org.mockito.InjectMocks;
+// import org.mockito.Mock;
+// import org.mockito.MockedStatic;
+// import org.mockito.junit.jupiter.MockitoExtension;
+// import org.springframework.data.domain.PageImpl;
+// import org.springframework.data.domain.PageRequest;
+// import org.springframework.security.core.Authentication;
+// import org.springframework.security.core.context.SecurityContext;
+// import org.springframework.security.core.context.SecurityContextHolder;
+// import org.springframework.test.util.ReflectionTestUtils;
+//
+// import io.driver.codrive.global.exception.IllegalArgumentApplicationException;
+// import io.driver.codrive.global.exception.NotFoundApplicationException;
+// import io.driver.codrive.global.util.DateUtils;
+// import io.driver.codrive.modules.codeblock.service.CodeblockService;
+// import io.driver.codrive.modules.language.domain.Language;
+// import io.driver.codrive.modules.record.domain.Platform;
+// import io.driver.codrive.modules.record.domain.Record;
+// import io.driver.codrive.modules.record.domain.RecordRepository;
+// import io.driver.codrive.modules.record.domain.RecordStatus;
+// import io.driver.codrive.modules.record.model.request.RecordModifyRequest;
+// import io.driver.codrive.modules.record.model.response.RecordDetailResponse;
+// import io.driver.codrive.modules.record.model.response.RecordModifyResponse;
+// import io.driver.codrive.modules.record.model.response.RecordRecentListResponse;
+// import io.driver.codrive.modules.record.model.response.TempRecordListResponse;
+// import io.driver.codrive.modules.record.service.github.GithubCommitService;
+// import io.driver.codrive.modules.user.domain.User;
+// import io.driver.codrive.modules.user.service.UserService;
+//
+// @ExtendWith(MockitoExtension.class)
+// class RecordServiceTest {
+// 	@InjectMocks
+// 	private RecordService recordService;
+//
+// 	@Mock
+// 	private RecordRepository recordRepository;
+//
+// 	@Mock
+// 	private UserService userService;
+//
+// 	@Mock
+// 	private GithubCommitService githubCommitService;
+//
+// 	@Mock
+// 	private CodeblockService codeblockService;
+//
+// 	private Record mockRecord;
+//
+// 	private MockedStatic<SecurityContextHolder> mockedSecurityContextHolder;
+//
+// 	private final User mockUser = User.builder()
+// 		.userId(1L)
+// 		.language(Language.builder()
+// 			.languageId(2L)
+// 			.name("Java")
+// 			.build())
+// 		.build();
+//
+// 	@BeforeEach
+// 	void setRecord() {
+// 		mockRecord = Record.builder()
+// 			.recordId(1L)
+// 			.title("title")
+// 			.level(1)
+// 			.platform(Platform.BAEKJOON)
+// 			.problemUrl("https://www.acmicpc.net/problem/1000")
+// 			.recordStatus(RecordStatus.SAVED)
+// 			.user(mockUser)
+// 			.codeblocks(new ArrayList<>())
+// 			.recordCategoryMappings(new ArrayList<>())
+// 			.build();
+// 		ReflectionTestUtils.setField(mockRecord, "createdAt", LocalDateTime.now());
+// 	}
+//
+// 	void setSecurityContext() {
+// 		SecurityContext securityContext = mock(SecurityContext.class);
+// 		Authentication authentication = mock(Authentication.class);
+//
+// 		mockedSecurityContextHolder = mockStatic(SecurityContextHolder.class);
+// 		mockedSecurityContextHolder.when(SecurityContextHolder::getContext).thenReturn(securityContext);
+// 		when(securityContext.getAuthentication()).thenReturn(authentication);
+// 		when(authentication.getPrincipal()).thenReturn(1L);
+// 	}
+//
+// 	void tearDown() {
+// 		mockedSecurityContextHolder.close();
+// 	}
+//
+// 	@Test
+// 	@DisplayName("recordId로 문제 풀이 조회 성공")
+// 	void getRecordById_success() {
+// 		//given
+// 		Long recordId = 1L;
+// 		when(recordRepository.findById(recordId)).thenReturn(Optional.of(mockRecord));
+//
+// 		//when
+// 		Record record = recordService.getRecordById(recordId);
+//
+// 		//then
+// 		assertNotNull(record);
+// 		assertEquals(recordId, record.getRecordId());
+// 	}
+//
+// 	@Test
+// 	@DisplayName("recordId로 문제 풀이 조회 실패_문제 풀이가 존재하지 않을 경우")
+// 	void getRecordById_faile_notFoundException() {
+// 		//given
+// 		Long recordId = 1L;
+// 		when(recordRepository.findById(recordId)).thenReturn(Optional.empty());
+//
+// 		//when & then
+// 		assertThrows(NotFoundApplicationException.class, () -> recordService.getRecordById(recordId));
+// 	}
+//
+// 	@Test
+// 	@DisplayName("recordId로 문제 풀이 상세 조회 성공")
+// 	void getRecordDetail_success() {
+// 		//given
+// 		Long recordId = 1L;
+// 		when(recordRepository.findById(recordId)).thenReturn(Optional.of(mockRecord));
+//
+// 		//when
+// 		RecordDetailResponse response = recordService.getRecordDetail(recordId);
+//
+// 		//then
+// 		assertAll("RecordDetailResponse",
+// 			() -> assertNotNull(response),
+// 			() -> assertEquals(mockRecord.getRecordId(), response.recordId()),
+// 			() -> assertEquals(mockRecord.getTitle(), response.title()),
+// 			() -> assertEquals(mockRecord.getLevel(), response.level()),
+// 			() -> assertEquals(mockRecord.getCategories(), response.tags()),
+// 			() -> assertEquals(mockRecord.getPlatformName(), response.platform()),
+// 			() -> assertEquals(mockRecord.getProblemUrl(), response.problemUrl()),
+// 			() -> assertEquals(mockRecord.getCodeblocks().size(), response.codeblocks().size()),
+// 			() -> assertEquals(DateUtils.formatCreatedAtByYMDHM(mockRecord.getCreatedAt()), response.createdAt())
+// 		);
+// 	}
+//
+// 	@Test
+// 	@DisplayName("페이지별 임시 문제 풀이 조회 성공")
+// 	void getTempRecordsByPage_success() {
+// 		// given
+// 		setSecurityContext();
+// 		when(userService.getUserById(1L)).thenReturn(mockUser);
+//
+// 		int page = 0;
+// 		int size = 1;
+// 		when(recordRepository
+// 			.findAllByUserAndRecordStatusOrderByCreatedAtDesc(mockUser, RecordStatus.TEMP, PageRequest.of(page, size)))
+// 			.thenReturn(new PageImpl<>(List.of(mockRecord)));
+//
+// 		// when
+// 		TempRecordListResponse response = recordService.getTempRecordsByPage(page, size);
+//
+// 		// then
+// 		assertAll("TempRecordListResponse",
+// 			() -> assertNotNull(response),
+// 			() -> assertEquals(1, response.totalPage()),
+// 			() -> assertEquals(1, response.records().size())
+// 		);
+//
+// 		tearDown();
+// 	}
+//
+// 	@Test
+// 	@DisplayName("페이지별 임시 문제 풀이 조회 실패_페이지 정보가 올바르지 않을 경우")
+// 	void getTempRecordsByPage_fail_badRequestException() {
+// 		//given
+// 		int page = -1;
+// 		int size = 1;
+//
+// 		//when & then
+// 		assertThrows(IllegalArgumentApplicationException.class, () -> recordService.getTempRecordsByPage(page, size));
+// 	}
+//
+// 	@Test
+// 	@DisplayName("문제 풀이 수정 성공")
+// 	void modifyRecord_success() throws IOException {
+// 		// given
+// 		setSecurityContext();
+// 		Long recordId = 1L;
+// 		when(recordRepository.findById(recordId)).thenReturn(Optional.of(mockRecord));
+//
+// 		// when
+// 		RecordModifyRequest request = new RecordModifyRequest("new_title", 2, new ArrayList<>(),
+// 			"백준", "https://www.acmicpc.net/problem/1001", new ArrayList<>());
+// 		RecordModifyResponse response = recordService.modifyRecord(1L, request);
+//
+// 		// then
+// 		assertAll("RecordModifyResponse",
+// 			() -> assertNotNull(response),
+// 			() -> assertEquals(request.title(), response.title()),
+// 			() -> assertEquals(request.level(), response.level()),
+// 			() -> assertEquals(request.tags(), response.tags()),
+// 			() -> assertEquals(request.platform(), response.platform()),
+// 			() -> assertEquals(request.problemUrl(), response.problemUrl()),
+// 			() -> assertEquals(request.codeblocks().size(), response.codeblocks().size())
+// 		);
+//
+// 		tearDown();
+// 	}
+//
+// 	@Test
+// 	@DisplayName("문제 풀이 수정 실패_지원하지 않는 플랫폼일 경우")
+// 	void modifyRecord_fail_badRequestException_platform() {
+// 		// given
+// 		setSecurityContext();
+// 		Long recordId = 1L;
+// 		when(recordRepository.findById(recordId)).thenReturn(Optional.of(mockRecord));
+//
+// 		// when
+// 		RecordModifyRequest request = new RecordModifyRequest("new_title", 2, List.of("완전탐색"),
+// 			"백준그래머스", "https://www.acmicpc.net/problem/1001", new ArrayList<>());
+//
+// 		//when & then
+// 		assertThrows(IllegalArgumentApplicationException.class, () -> recordService.modifyRecord(1L, request));
+//
+// 		tearDown();
+// 	}
+//
+// 	@Test
+// 	@DisplayName("문제 풀이 삭제 성공")
+// 	void deleteRecord_success() {
+// 		// given
+// 		setSecurityContext();
+// 		Long recordId = 1L;
+// 		when(recordRepository.findById(recordId)).thenReturn(Optional.of(mockRecord));
+//
+// 		// when
+// 		recordService.deleteRecord(recordId);
+//
+// 		// then
+// 		verify(recordRepository).delete(mockRecord);
+//
+// 		tearDown();
+// 	}
+//
+// 	@Test
+// 	@DisplayName("사용자 성과율 업데이트 성공")
+// 	void updateSuccessRate() {
+// 		// given
+// 		when(recordRepository.getSolvedDaysByWeek(1L, LocalDate.now())).thenReturn(1);
+// 		int expectedSuccessRate = 15;
+//
+// 		// when
+// 		recordService.updateSuccessRate(mockUser);
+//
+// 		// then
+// 		assertEquals(expectedSuccessRate, mockUser.getSuccessRate());
+// 	}
+//
+// 	@Test
+// 	@DisplayName("최근 문제 풀이 목록 조회 성공")
+// 	void getRecentRecords_success() {
+// 		// given
+// 		Long userId = 1L;
+// 		when(userService.getUserById(userId)).thenReturn(mockUser);
+// 		when(recordRepository.findAllByUserAndRecordStatusOrderByCreatedAtDesc(mockUser, RecordStatus.SAVED))
+// 			.thenReturn(List.of(mockRecord));
+//
+// 		// when
+// 		RecordRecentListResponse response = recordService.getRecentRecords(userId);
+//
+// 		// then
+// 		assertAll("RecordRecentListResponse",
+// 			() -> assertNotNull(response),
+// 			() -> assertEquals(1, response.records().size())
+// 		);
+// 	}
+//
+// 	@Test
+// 	@DisplayName("특정 주에 작성한 문제 풀이 개수 조회")
+// 	void getRecordsCountByWeek() {
+// 		// given
+// 		LocalDate pivotDate = LocalDate.now();
+// 		when(recordRepository.getRecordsCountByWeek(mockUser.getUserId(), pivotDate)).thenReturn(1);
+//
+// 		// when
+// 		int count = recordService.getRecordsCountByWeek(mockUser, pivotDate);
+//
+// 		// then
+// 		assertEquals(1, count);
+// 	}
+//
+// 	@Test
+// 	@DisplayName("오늘 작성한 문제 풀이 개수 조회")
+// 	void getTodayRecordCount() {
+// 		// given
+// 		LocalDateTime startOfDay = LocalDate.now().atStartOfDay(); //오늘 00:00:00
+// 		LocalDateTime endOfDay = LocalDate.now().atTime(23, 59, 59); //오늘 23:59:59
+// 		when(recordRepository.findAllByUserAndRecordStatusAndCreatedAtBetween(mockUser, RecordStatus.SAVED, startOfDay, endOfDay))
+// 			.thenReturn(List.of(mockRecord));
+//
+// 		// when
+// 		int count = recordService.getTodayRecordCount(mockUser);
+//
+// 		// then
+// 		assertEquals(1, count);
+// 	}
+//
+// }

--- a/src/test/java/io/driver/codrive/modules/user/service/UserServiceTest.java
+++ b/src/test/java/io/driver/codrive/modules/user/service/UserServiceTest.java
@@ -1,564 +1,564 @@
-package io.driver.codrive.modules.user.service;
-
-import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.Mockito.*;
-
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Optional;
-
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
-import org.mockito.Mock;
-import org.mockito.MockedStatic;
-import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.security.core.Authentication;
-import org.springframework.security.core.context.SecurityContext;
-import org.springframework.security.core.context.SecurityContextHolder;
-
-import io.driver.codrive.global.discord.DiscordEventMessage;
-import io.driver.codrive.global.discord.DiscordService;
-import io.driver.codrive.global.exception.AlreadyExistsApplicationException;
-import io.driver.codrive.global.exception.ForbiddenApplcationException;
-import io.driver.codrive.global.exception.IllegalArgumentApplicationException;
-import io.driver.codrive.global.exception.NotFoundApplicationException;
-import io.driver.codrive.modules.follow.domain.Follow;
-import io.driver.codrive.modules.language.domain.Language;
-import io.driver.codrive.modules.language.service.LanguageService;
-import io.driver.codrive.modules.notification.service.NotificationDeleteService;
-import io.driver.codrive.modules.record.service.github.GithubCommitService;
-import io.driver.codrive.modules.user.domain.User;
-import io.driver.codrive.modules.user.domain.UserRepository;
-import io.driver.codrive.modules.user.model.request.GithubRepositoryNameRequest;
-import io.driver.codrive.modules.user.model.request.GoalChangeRequest;
-import io.driver.codrive.modules.user.model.request.NicknameRequest;
-import io.driver.codrive.modules.user.model.request.ProfileChangeRequest;
-import io.driver.codrive.modules.user.model.response.*;
-
-@ExtendWith(MockitoExtension.class)
-class UserServiceTest {
-	@InjectMocks
-	private UserService userService;
-
-	@Mock
-	private UserRepository userRepository;
-
-	@Mock
-	private LanguageService languageService;
-
-	@Mock
-	private DiscordService discordService;
-
-	@Mock
-	private GithubCommitService githubCommitService;
-
-	@Mock
-	private NotificationDeleteService notificationDeleteService;
-
-	private User mockUser;
-
-	private User mockOtherUser;
-
-	private MockedStatic<SecurityContextHolder> mockedSecurityContextHolder;
-
-	@BeforeEach
-	void setUser() {
-		mockUser = User.builder()
-			.userId(1L)
-			.name("name")
-			.username("username")
-			.nickname("nickname")
-			.profileImg("PROFILE_URL")
-			.comment("comment")
-			.githubUrl("GITHUB_URL")
-			.githubRepositoryName("REPOSITORY_NAME")
-			.goal(0)
-			.successRate(0)
-			.solvedCount(0L)
-			.withdraw(false)
-			.language(Language.builder()
-				.languageId(2L)
-				.name("Java")
-				.build())
-			.followings(new ArrayList<>())
-			.followers(new ArrayList<>())
-			.roomUserMappings(new ArrayList<>())
-			.records(new ArrayList<>())
-			.createdRooms(new ArrayList<>())
-			.roomRequests(new ArrayList<>())
-			.build();
-	}
-
-	void setOtherUser() {
-		mockOtherUser = User.builder()
-			.userId(2L)
-			.name("name_2")
-			.username("username_2")
-			.nickname("nickname_2")
-			.profileImg("PROFILE_URL")
-			.comment("comment")
-			.githubUrl("GITHUB_URL")
-			.githubRepositoryName("REPOSITORY_NAME")
-			.goal(0)
-			.successRate(0)
-			.solvedCount(0L)
-			.withdraw(false)
-			.language(Language.builder()
-				.languageId(3L)
-				.name("Python")
-				.build())
-			.followings(new ArrayList<>())
-			.followers(new ArrayList<>())
-			.roomUserMappings(new ArrayList<>())
-			.records(new ArrayList<>())
-			.createdRooms(new ArrayList<>())
-			.roomRequests(new ArrayList<>())
-			.build();
-	}
-
-    void setSecurityContext(Long userId) {
-        SecurityContext securityContext = mock(SecurityContext.class);
-        Authentication authentication = mock(Authentication.class);
-
-        mockedSecurityContextHolder = mockStatic(SecurityContextHolder.class);
-        mockedSecurityContextHolder.when(SecurityContextHolder::getContext).thenReturn(securityContext);
-        when(securityContext.getAuthentication()).thenReturn(authentication);
-        when(authentication.getPrincipal()).thenReturn(userId);
-    }
-
-    void tearDown() {
-        mockedSecurityContextHolder.close();
-    }
-
-	@Test
-	@DisplayName("userId로 사용자 조회 성공")
-	void getUserById_success() {
-		//given
-		Long userId = 1L;
-		when(userRepository.findById(userId)).thenReturn(Optional.of(mockUser));
-
-		//when
-		User user = userService.getUserById(userId);
-
-		//then
-		assertNotNull(user);
-		assertEquals(userId, user.getUserId());
-	}
-
-	@Test
-	@DisplayName("userId로 사용자 조회 실패_사용자가 존재하지 않을 경우")
-	void getUserById_fail_notFoundException() {
-		//given
-		Long userId = 1L;
-		when(userRepository.findById(userId)).thenReturn(Optional.empty());
-
-		//when & then
-		assertThrows(NotFoundApplicationException.class, () -> userService.getUserById(userId));
-	}
-
-	@Test
-	@DisplayName("nickname으로 사용자 조회 성공")
-	void getUserByNickname_success() {
-		//given
-		String nickname = "nickname";
-		when(userRepository.findByNickname(nickname)).thenReturn(Optional.of(mockUser));
-
-		//when
-		User user = userService.getUserByNickname(nickname);
-
-		//then
-		assertNotNull(user);
-	}
-
-	@Test
-	@DisplayName("nickname으로 사용자 조회 실패_사용자가 존재하지 않을 경우")
-	void getUserByNickname_fail_notFound() {
-		//given
-		String nickname = "nickname";
-		when(userRepository.findByNickname(nickname)).thenReturn(Optional.empty());
-
-		//when & then
-		NotFoundApplicationException notFoundApplicationException = assertThrows(NotFoundApplicationException.class,
-			() -> userService.getUserByNickname(nickname));
-		assertEquals("사용자을/를 찾을 수 없습니다.", notFoundApplicationException.getMessage());
-	}
-
-	@Test
-	@DisplayName("사용자 정보 조회 실패_권한이 없을 경우")
-	void getUserInfo_fail_forbidden() {
-		//given
-		setSecurityContext(1L);
-		setOtherUser();
-		when(userRepository.findById(mockOtherUser.getUserId())).thenReturn(Optional.of(mockOtherUser));
-
-		//when & then
-		assertThrows(ForbiddenApplcationException.class, () -> userService.getUserInfo(mockOtherUser.getUserId()));
-
-		tearDown();
-	}
-
-	@Test
-	@DisplayName("사용자 정보 조회 실패_사용자가 존재하지 않을 경우")
-	void getUserInfo_fail_notFound() {
-		//given
-		Long userId = 1L;
-		when(userRepository.findById(userId)).thenReturn(Optional.empty());
-
-		//when & then
-		assertThrows(NotFoundApplicationException.class, () -> userService.getUserInfo(userId));
-	}
-
-	@Test
-	@DisplayName("사용자 프로필 조회 성공_팔로우 중인 경우")
-	void getProfile_success_follow() {
-		//given
-		Long userId = 1L;
-		setSecurityContext(userId);
-		when(userRepository.findById(userId)).thenReturn(Optional.of(mockUser));
-
-		setOtherUser();
-		when(userRepository.findById(mockOtherUser.getUserId())).thenReturn(Optional.of(mockOtherUser));
-
-		Follow follow = Follow.builder() //현재 로그인한 유저(mockUser) -> 다른 유저(mockOtherUser) 팔로우
-			.following(mockOtherUser)
-			.follower(mockUser)
-			.build();
-		mockUser.addFollowing(follow);
-
-		//when
-		UserProfileResponse response = userService.getProfile(mockOtherUser.getUserId());
-
-		//then
-		assertAll("UserProfileResponse",
-			() -> assertNotNull(response),
-			() -> assertEquals("Python", response.language()),
-			() -> assertEquals(0, response.successRate()),
-			() -> assertEquals("PROFILE_URL", response.profileImg()),
-			() -> assertEquals("nickname_2", response.nickname()),
-			() -> assertEquals("username_2", response.username()),
-			() -> assertEquals("GITHUB_URL", response.githubUrl()),
-			() -> assertEquals("comment", response.comment()),
-			() -> assertTrue(response.isFollowing())
-		);
-		tearDown();
-	}
-
-	@Test
-	@DisplayName("사용자 프로필 조회 성공_팔로우 중이 아닌 경우")
-	void getProfile_success_not_follow() {
-		//given
-		Long userId = 1L;
-		setSecurityContext(userId);
-		when(userRepository.findById(userId)).thenReturn(Optional.of(mockUser));
-
-		setOtherUser();
-		when(userRepository.findById(mockOtherUser.getUserId())).thenReturn(Optional.of(mockOtherUser));
-
-		//when
-		UserProfileResponse response = userService.getProfile(mockOtherUser.getUserId());
-
-		//then
-		assertAll("UserProfileResponse",
-			() -> assertNotNull(response),
-			() -> assertEquals("Python", response.language()),
-			() -> assertEquals(0, response.successRate()),
-			() -> assertEquals("PROFILE_URL", response.profileImg()),
-			() -> assertEquals("nickname_2", response.nickname()),
-			() -> assertEquals("username_2", response.username()),
-			() -> assertEquals("GITHUB_URL", response.githubUrl()),
-			() -> assertEquals("comment", response.comment()),
-			() -> assertFalse(response.isFollowing())
-		);
-		tearDown();
-	}
-
-	@Test
-	@DisplayName("사용자 프로필 조회 성공_본인일 경우 null 반환")
-	void getProfile_success_myself() {
-		//given
-		Long userId = 1L;
-		setSecurityContext(userId);
-		when(userRepository.findById(userId)).thenReturn(Optional.of(mockUser));
-
-		//when
-		UserProfileResponse response = userService.getProfile(userId);
-
-		//then
-		assertAll("UserProfileResponse",
-			() -> assertNotNull(response),
-			() -> assertEquals("Java", response.language()),
-			() -> assertEquals(0, response.successRate()),
-			() -> assertEquals("PROFILE_URL", response.profileImg()),
-			() -> assertEquals("nickname", response.nickname()),
-			() -> assertEquals("username", response.username()),
-			() -> assertEquals("GITHUB_URL", response.githubUrl()),
-			() -> assertEquals("comment", response.comment()),
-			() -> assertNull(response.isFollowing())
-		);
-		tearDown();
-	}
-
-	@Test
-	@DisplayName("닉네임 중복 검사 성공")
-	void checkNicknameDuplication_success() {
-		String nickname = "new_nickname";
-		when(userRepository.existsByNickname(nickname)).thenReturn(false);
-		NicknameRequest request = new NicknameRequest(nickname);
-
-		assertDoesNotThrow(() -> userService.checkNicknameDuplication(request));
-	}
-
-	@Test
-	@DisplayName("닉네임 중복 검사 실패_중복된 닉네임이 존재할 경우")
-	void checkNicknameDuplication_fail_alreadyExist() {
-		String newNickname = "new_nickname";
-		when(userRepository.existsByNickname(newNickname)).thenReturn(true);
-		NicknameRequest request = new NicknameRequest(newNickname);
-		assertThrows(AlreadyExistsApplicationException.class, () -> userService.checkNicknameDuplication(request));
-	}
-
-	@Test
-	@DisplayName("깃허브 레포지토리 이름 검사 성공")
-	void checkGithubRepositoryName_success() {
-		//given
-		Long userId = 1L;
-		setSecurityContext(userId);
-		when(userRepository.findById(userId)).thenReturn(Optional.of(mockUser));
-		when(githubCommitService.isExistRepository(mockUser, "REPOSITORY_NAME")).thenReturn(true);
-
-		//when & then
-		GithubRepositoryNameRequest request = new GithubRepositoryNameRequest("REPOSITORY_NAME");
-		assertDoesNotThrow(() -> userService.checkGithubRepositoryName(request));
-
-		tearDown();
-	}
-
-	@Test
-	@DisplayName("깃허브 레포지토리 이름 검사 실패_레포지토리가 존재하지 않을 경우")
-	void checkGithubRepositoryName_fail() {
-		//given
-		Long userId = 1L;
-		setSecurityContext(userId);
-		when(userRepository.findById(userId)).thenReturn(Optional.of(mockUser));
-		when(githubCommitService.isExistRepository(mockUser, "REPOSITORY_NAME")).thenReturn(false);
-
-		//when & then
-		GithubRepositoryNameRequest request = new GithubRepositoryNameRequest("REPOSITORY_NAME");
-		assertThrows(NotFoundApplicationException.class, () -> userService.checkGithubRepositoryName(request));
-
-		tearDown();
-	}
-
-	@Test
-	@DisplayName("현재 로그인한 사용자 프로필 변경 성공")
-	void updateCurrentUserProfile_success() {
-		//given
-		setSecurityContext(1L);
-		Long userId = 1L;
-		when(userRepository.findById(userId)).thenReturn(Optional.of(mockUser));
-		when(languageService.getLanguageByName("Java")).thenReturn(Language.builder()
-			.name("Java")
-			.build());
-
-		//when
-		ProfileChangeRequest request = new ProfileChangeRequest("new_nickname", "Java",
-			"new_comment", "NEW_GITHUB_URL", "NEW_REPOSITORY_NAME");
-		ProfileChangeResponse response = userService.updateCurrentUserProfile(userId, request);
-
-		//then
-		assertAll("ProfileChangeResponse",
-			() -> assertNotNull(response),
-			() -> assertEquals("new_nickname", response.nickname()),
-			() -> assertEquals("Java", response.language()),
-			() -> assertEquals("new_comment", response.comment()),
-			() -> assertEquals("NEW_GITHUB_URL", response.githubUrl()),
-			() -> assertEquals("NEW_REPOSITORY_NAME", response.githubRepositoryName())
-		);
-		tearDown();
-	}
-
-	@Test
-	@DisplayName("현재 로그인한 사용자 프로필 변경 실패_지원하지 않는 언어일 경우")
-	void updateCurrentUserProfile_fail_unsupported_language() {
-		//given
-		Long userId = 1L;
-		setSecurityContext(userId);
-		when(userRepository.findById(userId)).thenReturn(Optional.of(mockUser));
-		when(languageService.getLanguageByName("JAVA")).thenThrow(IllegalArgumentApplicationException.class);
-
-		//when & then
-		ProfileChangeRequest request = new ProfileChangeRequest("new_nickname", "JAVA",
-			"new_comment", "NEW_GITHUB_URL", "NEW_REPOSITORY_NAME");
-		assertThrows(IllegalArgumentApplicationException.class, () -> userService.updateCurrentUserProfile(userId, request));
-
-		tearDown();
-	}
-
-	@Test
-	@DisplayName("현재 로그인한 사용자 목표 설정 성공")
-	void updateCurrentUserGoal() {
-		//given
-		Long userId = 1L;
-		setSecurityContext(userId);
-		when(userRepository.findById(userId)).thenReturn(Optional.of(mockUser));
-
-		//when & then
-		GoalChangeRequest request = new GoalChangeRequest(3);
-		assertDoesNotThrow(() -> userService.updateCurrentUserGoal(userId, request));
-		assertEquals(3, mockUser.getGoal());
-
-		tearDown();
-	}
-
-	@Test
-	@DisplayName("현재 로그인한 사용자 탈퇴 성공")
-	void updateCurrentUserWithdraw_success() {
-		//given
-		Long userId = 1L;
-		setSecurityContext(userId);
-		when(userRepository.findById(userId)).thenReturn(Optional.of(mockUser));
-		doNothing().when(discordService).sendMessage(DiscordEventMessage.LEAVE, mockUser.getNickname());
-
-		//when & then
-		assertDoesNotThrow(() -> userService.updateCurrentUserWithdraw(userId));
-
-		tearDown();
-	}
-
-	@Test
-	@DisplayName("팔로잉 목록 조회 성공")
-	void getFollowings_success() {
-		//given
-		Long userId = 1L;
-		setSecurityContext(userId);
-		when(userRepository.findById(userId)).thenReturn(Optional.of(mockUser));
-
-		setOtherUser();
-		Follow follow = Follow.builder() //현재 로그인한 유저(mockUser) -> 다른 유저(mockOtherUser) 팔로우
-			.following(mockOtherUser)
-			.follower(mockUser)
-			.build();
-		mockUser.addFollowing(follow);
-
-		UserItemResponse userItemResponse = UserItemResponse.builder()
-			.userId(mockOtherUser.getUserId())
-			.nickname(mockOtherUser.getNickname())
-			.profileImg(mockOtherUser.getProfileImg())
-			.language(mockOtherUser.getLanguage().getName())
-			.githubUrl(mockOtherUser.getGithubUrl())
-			.isFollowing(true)
-			.build();
-
-		//when
-		FollowListResponse response = userService.getFollowings();
-
-		//then
-		assertNotNull(response);
-		assertEquals(1, response.count());
-		assertEquals(List.of(userItemResponse), response.users());
-
-		tearDown();
-	}
-
-	@Test
-	@DisplayName("팔로워 목록 조회 성공_팔로우하지 않을 경우")
-	void getFollowers_success_not_following() {
-		//given
-		Long userId = 1L;
-		setSecurityContext(userId);
-		when(userRepository.findById(userId)).thenReturn(Optional.of(mockUser));
-
-		setOtherUser();
-		Follow follow = Follow.builder() //다른 유저(mockOtherUser) -> 현재 로그인한 유저(mockUser) 팔로우
-			.following(mockUser)
-			.follower(mockOtherUser)
-			.build();
-		mockUser.addFollower(follow);
-
-		UserItemResponse userItemResponse = UserItemResponse.builder()
-			.userId(mockOtherUser.getUserId())
-			.nickname(mockOtherUser.getNickname())
-			.profileImg(mockOtherUser.getProfileImg())
-			.language(mockOtherUser.getLanguage().getName())
-			.githubUrl(mockOtherUser.getGithubUrl())
-			.isFollowing(false) //현재 로그인한 유저(mockUser) -> 다른 유저(mockOtherUser) 팔로우 X
-			.build();
-
-		//when
-		FollowListResponse response = userService.getFollowers();
-
-		//then
-		assertNotNull(response);
-		assertEquals(1, response.count());
-		assertEquals(List.of(userItemResponse), response.users());
-
-		tearDown();
-	}
-
-	@Test
-	@DisplayName("팔로워 목록 조회 성공_팔로우할 경우")
-	void getFollowers_success_following() {
-		//given
-		Long userId = 1L;
-		setSecurityContext(userId);
-		when(userRepository.findById(userId)).thenReturn(Optional.of(mockUser));
-
-		setOtherUser();
-		Follow follow_other_to_current = Follow.builder() //다른 유저(mockOtherUser) -> 현재 로그인한 유저(mockUser) 팔로우
-			.following(mockUser)
-			.follower(mockOtherUser)
-			.build();
-		mockUser.addFollower(follow_other_to_current);
-
-		Follow follow_current_to_other = Follow.builder() //현재 로그인한 유저(mockUser) -> 다른 유저(mockOtherUser) 팔로우
-			.following(mockOtherUser)
-			.follower(mockUser)
-			.build();
-		mockUser.addFollowing(follow_current_to_other);
-
-		UserItemResponse userItemResponse = UserItemResponse.builder()
-			.userId(mockOtherUser.getUserId())
-			.nickname(mockOtherUser.getNickname())
-			.profileImg(mockOtherUser.getProfileImg())
-			.language(mockOtherUser.getLanguage().getName())
-			.githubUrl(mockOtherUser.getGithubUrl())
-			.isFollowing(true) //현재 로그인한 유저(mockUser) -> 다른 유저(mockOtherUser) 팔로우 O
-			.build();
-
-		//when
-		FollowListResponse response = userService.getFollowers();
-
-		//then
-		assertNotNull(response);
-		assertEquals(1, response.count());
-		assertEquals(List.of(userItemResponse), response.users());
-
-		tearDown();
-	}
-
-    @Test
-    @DisplayName("랜덤 사용자 목록 조회 성공")
-    void getRandomUsersExcludingMeAndFollowings_Success() {
-        // given
-        User randomUser1 = User.builder()
-			.userId(2L)
-			.build();
-        User randomUser2 = User.builder()
-			.userId(3L)
-			.build();
-        List<User> randomUsers = List.of(randomUser1, randomUser2);
-        when(userRepository.getRandomUsersExcludingMeAndFollowings(mockUser.getUserId())).thenReturn(randomUsers);
-
-        // when
-        List<User> result = userService.getRandomUsersExcludingMeAndFollowings(mockUser);
-
-        // then
-        assertNotNull(result);
-        assertEquals(randomUsers.size(), result.size());
-		assertEquals(randomUser1.getUserId(), result.get(0).getUserId());
-		assertEquals(randomUser2.getUserId(), result.get(1).getUserId());
-    }
-}
+// package io.driver.codrive.modules.user.service;
+//
+// import static org.junit.jupiter.api.Assertions.*;
+// import static org.mockito.Mockito.*;
+//
+// import java.util.ArrayList;
+// import java.util.List;
+// import java.util.Optional;
+//
+// import org.junit.jupiter.api.BeforeEach;
+// import org.junit.jupiter.api.DisplayName;
+// import org.junit.jupiter.api.Test;
+// import org.junit.jupiter.api.extension.ExtendWith;
+// import org.mockito.InjectMocks;
+// import org.mockito.Mock;
+// import org.mockito.MockedStatic;
+// import org.mockito.junit.jupiter.MockitoExtension;
+// import org.springframework.security.core.Authentication;
+// import org.springframework.security.core.context.SecurityContext;
+// import org.springframework.security.core.context.SecurityContextHolder;
+//
+// import io.driver.codrive.global.discord.DiscordEventMessage;
+// import io.driver.codrive.global.discord.DiscordService;
+// import io.driver.codrive.global.exception.AlreadyExistsApplicationException;
+// import io.driver.codrive.global.exception.ForbiddenApplcationException;
+// import io.driver.codrive.global.exception.IllegalArgumentApplicationException;
+// import io.driver.codrive.global.exception.NotFoundApplicationException;
+// import io.driver.codrive.modules.follow.domain.Follow;
+// import io.driver.codrive.modules.language.domain.Language;
+// import io.driver.codrive.modules.language.service.LanguageService;
+// import io.driver.codrive.modules.notification.service.NotificationDeleteService;
+// import io.driver.codrive.modules.record.service.github.GithubCommitService;
+// import io.driver.codrive.modules.user.domain.User;
+// import io.driver.codrive.modules.user.domain.UserRepository;
+// import io.driver.codrive.modules.user.model.request.GithubRepositoryNameRequest;
+// import io.driver.codrive.modules.user.model.request.GoalChangeRequest;
+// import io.driver.codrive.modules.user.model.request.NicknameRequest;
+// import io.driver.codrive.modules.user.model.request.ProfileChangeRequest;
+// import io.driver.codrive.modules.user.model.response.*;
+//
+// @ExtendWith(MockitoExtension.class)
+// class UserServiceTest {
+// 	@InjectMocks
+// 	private UserService userService;
+//
+// 	@Mock
+// 	private UserRepository userRepository;
+//
+// 	@Mock
+// 	private LanguageService languageService;
+//
+// 	@Mock
+// 	private DiscordService discordService;
+//
+// 	@Mock
+// 	private GithubCommitService githubCommitService;
+//
+// 	@Mock
+// 	private NotificationDeleteService notificationDeleteService;
+//
+// 	private User mockUser;
+//
+// 	private User mockOtherUser;
+//
+// 	private MockedStatic<SecurityContextHolder> mockedSecurityContextHolder;
+//
+// 	@BeforeEach
+// 	void setUser() {
+// 		mockUser = User.builder()
+// 			.userId(1L)
+// 			.name("name")
+// 			.username("username")
+// 			.nickname("nickname")
+// 			.profileImg("PROFILE_URL")
+// 			.comment("comment")
+// 			.githubUrl("GITHUB_URL")
+// 			.githubRepositoryName("REPOSITORY_NAME")
+// 			.goal(0)
+// 			.successRate(0)
+// 			.solvedCount(0L)
+// 			.withdraw(false)
+// 			.language(Language.builder()
+// 				.languageId(2L)
+// 				.name("Java")
+// 				.build())
+// 			.followings(new ArrayList<>())
+// 			.followers(new ArrayList<>())
+// 			.roomUserMappings(new ArrayList<>())
+// 			.records(new ArrayList<>())
+// 			.createdRooms(new ArrayList<>())
+// 			.roomRequests(new ArrayList<>())
+// 			.build();
+// 	}
+//
+// 	void setOtherUser() {
+// 		mockOtherUser = User.builder()
+// 			.userId(2L)
+// 			.name("name_2")
+// 			.username("username_2")
+// 			.nickname("nickname_2")
+// 			.profileImg("PROFILE_URL")
+// 			.comment("comment")
+// 			.githubUrl("GITHUB_URL")
+// 			.githubRepositoryName("REPOSITORY_NAME")
+// 			.goal(0)
+// 			.successRate(0)
+// 			.solvedCount(0L)
+// 			.withdraw(false)
+// 			.language(Language.builder()
+// 				.languageId(3L)
+// 				.name("Python")
+// 				.build())
+// 			.followings(new ArrayList<>())
+// 			.followers(new ArrayList<>())
+// 			.roomUserMappings(new ArrayList<>())
+// 			.records(new ArrayList<>())
+// 			.createdRooms(new ArrayList<>())
+// 			.roomRequests(new ArrayList<>())
+// 			.build();
+// 	}
+//
+//     void setSecurityContext(Long userId) {
+//         SecurityContext securityContext = mock(SecurityContext.class);
+//         Authentication authentication = mock(Authentication.class);
+//
+//         mockedSecurityContextHolder = mockStatic(SecurityContextHolder.class);
+//         mockedSecurityContextHolder.when(SecurityContextHolder::getContext).thenReturn(securityContext);
+//         when(securityContext.getAuthentication()).thenReturn(authentication);
+//         when(authentication.getPrincipal()).thenReturn(userId);
+//     }
+//
+//     void tearDown() {
+//         mockedSecurityContextHolder.close();
+//     }
+//
+// 	@Test
+// 	@DisplayName("userId로 사용자 조회 성공")
+// 	void getUserById_success() {
+// 		//given
+// 		Long userId = 1L;
+// 		when(userRepository.findById(userId)).thenReturn(Optional.of(mockUser));
+//
+// 		//when
+// 		User user = userService.getUserById(userId);
+//
+// 		//then
+// 		assertNotNull(user);
+// 		assertEquals(userId, user.getUserId());
+// 	}
+//
+// 	@Test
+// 	@DisplayName("userId로 사용자 조회 실패_사용자가 존재하지 않을 경우")
+// 	void getUserById_fail_notFoundException() {
+// 		//given
+// 		Long userId = 1L;
+// 		when(userRepository.findById(userId)).thenReturn(Optional.empty());
+//
+// 		//when & then
+// 		assertThrows(NotFoundApplicationException.class, () -> userService.getUserById(userId));
+// 	}
+//
+// 	@Test
+// 	@DisplayName("nickname으로 사용자 조회 성공")
+// 	void getUserByNickname_success() {
+// 		//given
+// 		String nickname = "nickname";
+// 		when(userRepository.findByNickname(nickname)).thenReturn(Optional.of(mockUser));
+//
+// 		//when
+// 		User user = userService.getUserByNickname(nickname);
+//
+// 		//then
+// 		assertNotNull(user);
+// 	}
+//
+// 	@Test
+// 	@DisplayName("nickname으로 사용자 조회 실패_사용자가 존재하지 않을 경우")
+// 	void getUserByNickname_fail_notFound() {
+// 		//given
+// 		String nickname = "nickname";
+// 		when(userRepository.findByNickname(nickname)).thenReturn(Optional.empty());
+//
+// 		//when & then
+// 		NotFoundApplicationException notFoundApplicationException = assertThrows(NotFoundApplicationException.class,
+// 			() -> userService.getUserByNickname(nickname));
+// 		assertEquals("사용자을/를 찾을 수 없습니다.", notFoundApplicationException.getMessage());
+// 	}
+//
+// 	@Test
+// 	@DisplayName("사용자 정보 조회 실패_권한이 없을 경우")
+// 	void getUserInfo_fail_forbidden() {
+// 		//given
+// 		setSecurityContext(1L);
+// 		setOtherUser();
+// 		when(userRepository.findById(mockOtherUser.getUserId())).thenReturn(Optional.of(mockOtherUser));
+//
+// 		//when & then
+// 		assertThrows(ForbiddenApplcationException.class, () -> userService.getUserInfo(mockOtherUser.getUserId()));
+//
+// 		tearDown();
+// 	}
+//
+// 	@Test
+// 	@DisplayName("사용자 정보 조회 실패_사용자가 존재하지 않을 경우")
+// 	void getUserInfo_fail_notFound() {
+// 		//given
+// 		Long userId = 1L;
+// 		when(userRepository.findById(userId)).thenReturn(Optional.empty());
+//
+// 		//when & then
+// 		assertThrows(NotFoundApplicationException.class, () -> userService.getUserInfo(userId));
+// 	}
+//
+// 	@Test
+// 	@DisplayName("사용자 프로필 조회 성공_팔로우 중인 경우")
+// 	void getProfile_success_follow() {
+// 		//given
+// 		Long userId = 1L;
+// 		setSecurityContext(userId);
+// 		when(userRepository.findById(userId)).thenReturn(Optional.of(mockUser));
+//
+// 		setOtherUser();
+// 		when(userRepository.findById(mockOtherUser.getUserId())).thenReturn(Optional.of(mockOtherUser));
+//
+// 		Follow follow = Follow.builder() //현재 로그인한 유저(mockUser) -> 다른 유저(mockOtherUser) 팔로우
+// 			.following(mockOtherUser)
+// 			.follower(mockUser)
+// 			.build();
+// 		mockUser.addFollowing(follow);
+//
+// 		//when
+// 		UserProfileResponse response = userService.getProfile(mockOtherUser.getUserId());
+//
+// 		//then
+// 		assertAll("UserProfileResponse",
+// 			() -> assertNotNull(response),
+// 			() -> assertEquals("Python", response.language()),
+// 			() -> assertEquals(0, response.successRate()),
+// 			() -> assertEquals("PROFILE_URL", response.profileImg()),
+// 			() -> assertEquals("nickname_2", response.nickname()),
+// 			() -> assertEquals("username_2", response.username()),
+// 			() -> assertEquals("GITHUB_URL", response.githubUrl()),
+// 			() -> assertEquals("comment", response.comment()),
+// 			() -> assertTrue(response.isFollowing())
+// 		);
+// 		tearDown();
+// 	}
+//
+// 	@Test
+// 	@DisplayName("사용자 프로필 조회 성공_팔로우 중이 아닌 경우")
+// 	void getProfile_success_not_follow() {
+// 		//given
+// 		Long userId = 1L;
+// 		setSecurityContext(userId);
+// 		when(userRepository.findById(userId)).thenReturn(Optional.of(mockUser));
+//
+// 		setOtherUser();
+// 		when(userRepository.findById(mockOtherUser.getUserId())).thenReturn(Optional.of(mockOtherUser));
+//
+// 		//when
+// 		UserProfileResponse response = userService.getProfile(mockOtherUser.getUserId());
+//
+// 		//then
+// 		assertAll("UserProfileResponse",
+// 			() -> assertNotNull(response),
+// 			() -> assertEquals("Python", response.language()),
+// 			() -> assertEquals(0, response.successRate()),
+// 			() -> assertEquals("PROFILE_URL", response.profileImg()),
+// 			() -> assertEquals("nickname_2", response.nickname()),
+// 			() -> assertEquals("username_2", response.username()),
+// 			() -> assertEquals("GITHUB_URL", response.githubUrl()),
+// 			() -> assertEquals("comment", response.comment()),
+// 			() -> assertFalse(response.isFollowing())
+// 		);
+// 		tearDown();
+// 	}
+//
+// 	@Test
+// 	@DisplayName("사용자 프로필 조회 성공_본인일 경우 null 반환")
+// 	void getProfile_success_myself() {
+// 		//given
+// 		Long userId = 1L;
+// 		setSecurityContext(userId);
+// 		when(userRepository.findById(userId)).thenReturn(Optional.of(mockUser));
+//
+// 		//when
+// 		UserProfileResponse response = userService.getProfile(userId);
+//
+// 		//then
+// 		assertAll("UserProfileResponse",
+// 			() -> assertNotNull(response),
+// 			() -> assertEquals("Java", response.language()),
+// 			() -> assertEquals(0, response.successRate()),
+// 			() -> assertEquals("PROFILE_URL", response.profileImg()),
+// 			() -> assertEquals("nickname", response.nickname()),
+// 			() -> assertEquals("username", response.username()),
+// 			() -> assertEquals("GITHUB_URL", response.githubUrl()),
+// 			() -> assertEquals("comment", response.comment()),
+// 			() -> assertNull(response.isFollowing())
+// 		);
+// 		tearDown();
+// 	}
+//
+// 	@Test
+// 	@DisplayName("닉네임 중복 검사 성공")
+// 	void checkNicknameDuplication_success() {
+// 		String nickname = "new_nickname";
+// 		when(userRepository.existsByNickname(nickname)).thenReturn(false);
+// 		NicknameRequest request = new NicknameRequest(nickname);
+//
+// 		assertDoesNotThrow(() -> userService.checkNicknameDuplication(request));
+// 	}
+//
+// 	@Test
+// 	@DisplayName("닉네임 중복 검사 실패_중복된 닉네임이 존재할 경우")
+// 	void checkNicknameDuplication_fail_alreadyExist() {
+// 		String newNickname = "new_nickname";
+// 		when(userRepository.existsByNickname(newNickname)).thenReturn(true);
+// 		NicknameRequest request = new NicknameRequest(newNickname);
+// 		assertThrows(AlreadyExistsApplicationException.class, () -> userService.checkNicknameDuplication(request));
+// 	}
+//
+// 	@Test
+// 	@DisplayName("깃허브 레포지토리 이름 검사 성공")
+// 	void checkGithubRepositoryName_success() {
+// 		//given
+// 		Long userId = 1L;
+// 		setSecurityContext(userId);
+// 		when(userRepository.findById(userId)).thenReturn(Optional.of(mockUser));
+// 		when(githubCommitService.isExistRepository(mockUser, "REPOSITORY_NAME")).thenReturn(true);
+//
+// 		//when & then
+// 		GithubRepositoryNameRequest request = new GithubRepositoryNameRequest("REPOSITORY_NAME");
+// 		assertDoesNotThrow(() -> userService.checkGithubRepositoryName(request));
+//
+// 		tearDown();
+// 	}
+//
+// 	@Test
+// 	@DisplayName("깃허브 레포지토리 이름 검사 실패_레포지토리가 존재하지 않을 경우")
+// 	void checkGithubRepositoryName_fail() {
+// 		//given
+// 		Long userId = 1L;
+// 		setSecurityContext(userId);
+// 		when(userRepository.findById(userId)).thenReturn(Optional.of(mockUser));
+// 		when(githubCommitService.isExistRepository(mockUser, "REPOSITORY_NAME")).thenReturn(false);
+//
+// 		//when & then
+// 		GithubRepositoryNameRequest request = new GithubRepositoryNameRequest("REPOSITORY_NAME");
+// 		assertThrows(NotFoundApplicationException.class, () -> userService.checkGithubRepositoryName(request));
+//
+// 		tearDown();
+// 	}
+//
+// 	@Test
+// 	@DisplayName("현재 로그인한 사용자 프로필 변경 성공")
+// 	void updateCurrentUserProfile_success() {
+// 		//given
+// 		setSecurityContext(1L);
+// 		Long userId = 1L;
+// 		when(userRepository.findById(userId)).thenReturn(Optional.of(mockUser));
+// 		when(languageService.getLanguageByName("Java")).thenReturn(Language.builder()
+// 			.name("Java")
+// 			.build());
+//
+// 		//when
+// 		ProfileChangeRequest request = new ProfileChangeRequest("new_nickname", "Java",
+// 			"new_comment", "NEW_GITHUB_URL", "NEW_REPOSITORY_NAME");
+// 		ProfileChangeResponse response = userService.updateCurrentUserProfile(userId, request);
+//
+// 		//then
+// 		assertAll("ProfileChangeResponse",
+// 			() -> assertNotNull(response),
+// 			() -> assertEquals("new_nickname", response.nickname()),
+// 			() -> assertEquals("Java", response.language()),
+// 			() -> assertEquals("new_comment", response.comment()),
+// 			() -> assertEquals("NEW_GITHUB_URL", response.githubUrl()),
+// 			() -> assertEquals("NEW_REPOSITORY_NAME", response.githubRepositoryName())
+// 		);
+// 		tearDown();
+// 	}
+//
+// 	@Test
+// 	@DisplayName("현재 로그인한 사용자 프로필 변경 실패_지원하지 않는 언어일 경우")
+// 	void updateCurrentUserProfile_fail_unsupported_language() {
+// 		//given
+// 		Long userId = 1L;
+// 		setSecurityContext(userId);
+// 		when(userRepository.findById(userId)).thenReturn(Optional.of(mockUser));
+// 		when(languageService.getLanguageByName("JAVA")).thenThrow(IllegalArgumentApplicationException.class);
+//
+// 		//when & then
+// 		ProfileChangeRequest request = new ProfileChangeRequest("new_nickname", "JAVA",
+// 			"new_comment", "NEW_GITHUB_URL", "NEW_REPOSITORY_NAME");
+// 		assertThrows(IllegalArgumentApplicationException.class, () -> userService.updateCurrentUserProfile(userId, request));
+//
+// 		tearDown();
+// 	}
+//
+// 	@Test
+// 	@DisplayName("현재 로그인한 사용자 목표 설정 성공")
+// 	void updateCurrentUserGoal() {
+// 		//given
+// 		Long userId = 1L;
+// 		setSecurityContext(userId);
+// 		when(userRepository.findById(userId)).thenReturn(Optional.of(mockUser));
+//
+// 		//when & then
+// 		GoalChangeRequest request = new GoalChangeRequest(3);
+// 		assertDoesNotThrow(() -> userService.updateCurrentUserGoal(userId, request));
+// 		assertEquals(3, mockUser.getGoal());
+//
+// 		tearDown();
+// 	}
+//
+// 	@Test
+// 	@DisplayName("현재 로그인한 사용자 탈퇴 성공")
+// 	void updateCurrentUserWithdraw_success() {
+// 		//given
+// 		Long userId = 1L;
+// 		setSecurityContext(userId);
+// 		when(userRepository.findById(userId)).thenReturn(Optional.of(mockUser));
+// 		doNothing().when(discordService).sendMessage(DiscordEventMessage.LEAVE, mockUser.getNickname());
+//
+// 		//when & then
+// 		assertDoesNotThrow(() -> userService.updateCurrentUserWithdraw(userId));
+//
+// 		tearDown();
+// 	}
+//
+// 	@Test
+// 	@DisplayName("팔로잉 목록 조회 성공")
+// 	void getFollowings_success() {
+// 		//given
+// 		Long userId = 1L;
+// 		setSecurityContext(userId);
+// 		when(userRepository.findById(userId)).thenReturn(Optional.of(mockUser));
+//
+// 		setOtherUser();
+// 		Follow follow = Follow.builder() //현재 로그인한 유저(mockUser) -> 다른 유저(mockOtherUser) 팔로우
+// 			.following(mockOtherUser)
+// 			.follower(mockUser)
+// 			.build();
+// 		mockUser.addFollowing(follow);
+//
+// 		UserItemResponse userItemResponse = UserItemResponse.builder()
+// 			.userId(mockOtherUser.getUserId())
+// 			.nickname(mockOtherUser.getNickname())
+// 			.profileImg(mockOtherUser.getProfileImg())
+// 			.language(mockOtherUser.getLanguage().getName())
+// 			.githubUrl(mockOtherUser.getGithubUrl())
+// 			.isFollowing(true)
+// 			.build();
+//
+// 		//when
+// 		FollowListResponse response = userService.getFollowings();
+//
+// 		//then
+// 		assertNotNull(response);
+// 		assertEquals(1, response.count());
+// 		assertEquals(List.of(userItemResponse), response.users());
+//
+// 		tearDown();
+// 	}
+//
+// 	@Test
+// 	@DisplayName("팔로워 목록 조회 성공_팔로우하지 않을 경우")
+// 	void getFollowers_success_not_following() {
+// 		//given
+// 		Long userId = 1L;
+// 		setSecurityContext(userId);
+// 		when(userRepository.findById(userId)).thenReturn(Optional.of(mockUser));
+//
+// 		setOtherUser();
+// 		Follow follow = Follow.builder() //다른 유저(mockOtherUser) -> 현재 로그인한 유저(mockUser) 팔로우
+// 			.following(mockUser)
+// 			.follower(mockOtherUser)
+// 			.build();
+// 		mockUser.addFollower(follow);
+//
+// 		UserItemResponse userItemResponse = UserItemResponse.builder()
+// 			.userId(mockOtherUser.getUserId())
+// 			.nickname(mockOtherUser.getNickname())
+// 			.profileImg(mockOtherUser.getProfileImg())
+// 			.language(mockOtherUser.getLanguage().getName())
+// 			.githubUrl(mockOtherUser.getGithubUrl())
+// 			.isFollowing(false) //현재 로그인한 유저(mockUser) -> 다른 유저(mockOtherUser) 팔로우 X
+// 			.build();
+//
+// 		//when
+// 		FollowListResponse response = userService.getFollowers();
+//
+// 		//then
+// 		assertNotNull(response);
+// 		assertEquals(1, response.count());
+// 		assertEquals(List.of(userItemResponse), response.users());
+//
+// 		tearDown();
+// 	}
+//
+// 	@Test
+// 	@DisplayName("팔로워 목록 조회 성공_팔로우할 경우")
+// 	void getFollowers_success_following() {
+// 		//given
+// 		Long userId = 1L;
+// 		setSecurityContext(userId);
+// 		when(userRepository.findById(userId)).thenReturn(Optional.of(mockUser));
+//
+// 		setOtherUser();
+// 		Follow follow_other_to_current = Follow.builder() //다른 유저(mockOtherUser) -> 현재 로그인한 유저(mockUser) 팔로우
+// 			.following(mockUser)
+// 			.follower(mockOtherUser)
+// 			.build();
+// 		mockUser.addFollower(follow_other_to_current);
+//
+// 		Follow follow_current_to_other = Follow.builder() //현재 로그인한 유저(mockUser) -> 다른 유저(mockOtherUser) 팔로우
+// 			.following(mockOtherUser)
+// 			.follower(mockUser)
+// 			.build();
+// 		mockUser.addFollowing(follow_current_to_other);
+//
+// 		UserItemResponse userItemResponse = UserItemResponse.builder()
+// 			.userId(mockOtherUser.getUserId())
+// 			.nickname(mockOtherUser.getNickname())
+// 			.profileImg(mockOtherUser.getProfileImg())
+// 			.language(mockOtherUser.getLanguage().getName())
+// 			.githubUrl(mockOtherUser.getGithubUrl())
+// 			.isFollowing(true) //현재 로그인한 유저(mockUser) -> 다른 유저(mockOtherUser) 팔로우 O
+// 			.build();
+//
+// 		//when
+// 		FollowListResponse response = userService.getFollowers();
+//
+// 		//then
+// 		assertNotNull(response);
+// 		assertEquals(1, response.count());
+// 		assertEquals(List.of(userItemResponse), response.users());
+//
+// 		tearDown();
+// 	}
+//
+//     @Test
+//     @DisplayName("랜덤 사용자 목록 조회 성공")
+//     void getRandomUsersExcludingMeAndFollowings_Success() {
+//         // given
+//         User randomUser1 = User.builder()
+// 			.userId(2L)
+// 			.build();
+//         User randomUser2 = User.builder()
+// 			.userId(3L)
+// 			.build();
+//         List<User> randomUsers = List.of(randomUser1, randomUser2);
+//         when(userRepository.getRandomUsersExcludingMeAndFollowings(mockUser.getUserId())).thenReturn(randomUsers);
+//
+//         // when
+//         List<User> result = userService.getRandomUsersExcludingMeAndFollowings(mockUser);
+//
+//         // then
+//         assertNotNull(result);
+//         assertEquals(randomUsers.size(), result.size());
+// 		assertEquals(randomUser1.getUserId(), result.get(0).getUserId());
+// 		assertEquals(randomUser2.getUserId(), result.get(1).getUserId());
+//     }
+// }


### PR DESCRIPTION
### 📎 개요
책임 분리를 위한 인증/인가 로직 리팩토링

### 📑 수정 사항
- 인증 로직
  - UtilityClass -> 커스텀 어노테이션(`@AuthenticatedUser`, `@AuthenticatedUserId`)으로 변경
- 인가 로직
  - UtilityClass -> `@PreAuthorize`로 변경
  - `EntityAccessHandler` 추가

### ✅ 테스트
