### PR TITLE
[#127] 그룹 필터링 조회 API 리팩토링

### DIFF
--- a/src/main/java/io/driver/codrive/modules/record/domain/RecordRepositoryImpl.java
+++ b/src/main/java/io/driver/codrive/modules/record/domain/RecordRepositoryImpl.java
@@ -1,11 +1,11 @@
 package io.driver.codrive.modules.record.domain;
 
-import java.time.DayOfWeek;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.support.QuerydslRepositorySupport;
 import org.springframework.stereotype.Repository;
@@ -18,11 +18,11 @@ import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.Expressions;
 import com.querydsl.core.types.dsl.StringTemplate;
+import com.querydsl.jpa.JPQLQuery;
 
 import io.driver.codrive.global.exception.IllegalArgumentApplicationException;
 import io.driver.codrive.global.model.SortType;
 import io.driver.codrive.global.util.DateUtils;
-import io.driver.codrive.global.util.PageUtils;
 import io.driver.codrive.modules.record.model.dto.RecordCountDto;
 
 @Repository
@@ -35,12 +35,16 @@ public class RecordRepositoryImpl extends QuerydslRepositorySupport implements R
 	public Page<Record> getMonthlyRecords(Long userId, LocalDate pivotDate, SortType sortType, Pageable pageable) {
 		StringTemplate formattedYearMonth = getFormattedDate("%Y-%m");
 		String pivotDateYearMonth = DateUtils.formatYearMonth(pivotDate);
-		List<Record> records = from(record)
+		JPQLQuery<Record> query = from(record)
 			.where(record.user.userId.eq(userId), formattedYearMonth.eq(pivotDateYearMonth),
 				record.recordStatus.eq(RecordStatus.SAVED))
-			.orderBy(createRecordOrderSpecifier(sortType))
+			.orderBy(createRecordOrderSpecifier(sortType));
+
+		long total = query.fetchCount();
+		List<Record> records = query.offset(pageable.getOffset())
+			.limit(pageable.getPageSize())
 			.fetch();
-		return PageUtils.getPage(records, pageable, records.size());
+		return new PageImpl<>(records, pageable, total);
 	}
 
 	@Override
@@ -111,5 +115,5 @@ public class RecordRepositoryImpl extends QuerydslRepositorySupport implements R
 		} else {
 			throw new IllegalArgumentApplicationException("지원하지 않는 정렬 방식입니다.");
 		}
-    }
+	}
 }

--- a/src/main/java/io/driver/codrive/modules/room/domain/RoomRepositoryImpl.java
+++ b/src/main/java/io/driver/codrive/modules/room/domain/RoomRepositoryImpl.java
@@ -3,6 +3,7 @@ package io.driver.codrive.modules.room.domain;
 import java.util.List;
 
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.support.QuerydslRepositorySupport;
 import org.springframework.stereotype.Repository;
@@ -19,7 +20,6 @@ import static io.driver.codrive.modules.room.domain.QRoom.room;
 import static io.driver.codrive.modules.language.domain.QLanguage.language;
 
 import io.driver.codrive.global.model.SortType;
-import io.driver.codrive.global.util.PageUtils;
 import io.driver.codrive.modules.room.model.dto.RoomFilterDto;
 
 @Repository
@@ -38,7 +38,9 @@ public class RoomRepositoryImpl extends QuerydslRepositorySupport implements Roo
 			.join(room.roomLanguageMappings, roomLanguageMapping)
 			.join(roomLanguageMapping.language, language)
 			.where(
-				language.languageId.eq(languageId).and(room.roomStatus.eq(RoomStatus.ACTIVE)).and((room.password.isNull().or(room.password.isEmpty())))
+				language.languageId.eq(languageId)
+					.and(room.roomStatus.eq(RoomStatus.ACTIVE))
+					.and((room.password.isNull().or(room.password.isEmpty())))
 					.and(room.roomId.notIn(
 						JPAExpressions
 							.select(roomUserMapping.room.roomId)
@@ -62,8 +64,12 @@ public class RoomRepositoryImpl extends QuerydslRepositorySupport implements Roo
 			query.groupBy(roomLanguageMapping.room)
 			.having(roomLanguageMapping.language.countDistinct().eq((long) roomFilterDto.tagIds().size()));
 		}
-		List<Room> rooms = query.fetch();
-		return PageUtils.getPage(rooms, pageable, rooms.size());
+
+		long total = query.fetchCount();
+		List<Room> rooms = query.limit(pageable.getPageSize())
+			.offset(pageable.getOffset())
+			.fetch();
+		return new PageImpl<>(rooms, pageable, total);
 	}
 
 	private Predicate getRoomFilterRequest(RoomFilterDto roomFilterDto) {


### PR DESCRIPTION
### 📎 개요
그룹 필터링 조회 API 리팩토링

### 📑 수정 사항
- 페이징 로직 수정 -> `RoomRepository`, `RecordRepository` limit, offset 쿼리 추가
- DB -> 인덱스 적용
 
### ✅ 테스트
